### PR TITLE
Unskipping test; v6 fixed the property injection issue

### DIFF
--- a/test/Autofac.Extras.DynamicProxy.Test/InterfaceInterceptionWithPropertyInjectionFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/InterfaceInterceptionWithPropertyInjectionFixture.cs
@@ -27,7 +27,7 @@ namespace Autofac.Extras.DynamicProxy.Test
             Assert.Equal("intercepted-PublicMethod", obj.PublicMethod());
         }
 
-        [Fact(Skip = "https://github.com/autofac/Autofac/issues/758")]
+        [Fact]
         public void InterfaceInterceptorsSupportCircularPropertyInjection()
         {
             var builder = new ContainerBuilder();


### PR DESCRIPTION
The fix in Autofac for https://github.com/autofac/Autofac/issues/1204 fixes #40; this PR just unskips the test.

@alexmg, noticed you are working on shipping this package; might be worth merging this in before the tag.