### PR TITLE
Update the dependency on Autofac to version 6.2.0 

### DIFF
--- a/src/Autofac.Extras.DynamicProxy/Autofac.Extras.DynamicProxy.csproj
+++ b/src/Autofac.Extras.DynamicProxy/Autofac.Extras.DynamicProxy.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.0.0" />
+    <PackageReference Include="Autofac" Version="6.2.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
       <PrivateAssets>All</PrivateAssets>


### PR DESCRIPTION
since there was a breaking change in the Autofact package making the dlls binary incompatible (ConfigurationActions moved to base class)

https://github.com/autofac/Autofac/commit/76c2813d979cd713e9da8978f281e0941966913f