### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,90 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -118,20 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -157,48 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-end_of_line = crlf
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
-
-# YAML - match standard YAML like Kubernetes and GitHub Actions
-[*.{yaml,yml}]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -8,13 +8,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e  # frozen: v0.48.0
+    rev: "e72a3ca1632f0b11a07d171449fe447a7ff6795e"  # frozen: v0.48.0
     hooks:
       - id: markdownlint
         args:
           - --fix
   - repo: https://github.com/tillig/json-sort-cli
-    rev: 2b7e147e0933bd30b58133b6f287e5c695ff4f0e  # frozen: v3.0.1
+    rev: "2b7e147e0933bd30b58133b6f287e5c695ff4f0e"  # frozen: v3.0.1
     hooks:
       - id: json-sort
         args:

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,49 +4,39 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
-    <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
-    <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- Modifiers are not ordered - .editorconfig handles this -->
-    <Rule Id="SA1206" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- Parameter documentation must be in the right order -->
-    <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
-    <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
-    <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -2,65 +2,86 @@
 <RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
+    <Rule Id="CA1005" Action="Warning" />
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+    <Rule Id="CA1031" Action="None" />
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
-    <!-- Do not nest types - we do that special for the DynamicProxy testing because there are lots of overlapping scenarios to test and interfaces/classes do need to be public. -->
-    <Rule Id="CA1034" Action="None" />
-    <!-- Identifiers should not contain underscores - underscores are helpful in test naming. -->
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <Rule Id="CA1040" Action="None" />
+    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <Rule Id="CA1303" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <Rule Id="CA1515" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
     <Rule Id="CA1816" Action="None" />
     <!-- Mark members static - test methods may not access member data but also can't be static. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
+    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
+    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
+    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1204" Action="None" />
-    <!-- Modifiers are not ordered - .editorconfig handles this -->
-    <Rule Id="SA1206" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- Elements should be documented -->
+    <!-- Elements should be documented. -->
     <Rule Id="SA1600" Action="None" />
-    <!-- Enuemration items should be documented -->
+    <!-- Partial items should be documented. -->
+    <Rule Id="SA1601" Action="None" />
+    <!-- Enumeration items should be documented. -->
     <Rule Id="SA1602" Action="None" />
-    <!-- Parameter documentation must be in the right order -->
+    <!-- Parameter should be documented. -->
+    <Rule Id="SA1611" Action="None" />
+    <!-- Parameter documentation must be in the right order. -->
     <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
+    <!-- Return value must be documented. -->
     <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
+    <!-- Generic type parameters must be documented. -->
     <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
+    <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
-    <Rule Id="SA1633" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -9,6 +9,9 @@
         "licenseName": "MIT"
       },
       "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
     }
   }
 }

--- a/default.proj
+++ b/default.proj
@@ -1,41 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">7.1.0</PackageVersion>
-    <Solution>$(MSBuildThisFileDirectory)Autofac.Extras.DynamicProxy.sln</Solution>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
-    <PackagesPath>$(ArtifactsPath)/packages</PackagesPath>
-    <LogsPath>$(ArtifactsPath)/logs</LogsPath>
+    <!-- Increment the overall semantic version here. -->
+    <Version>7.1.0</Version>
+    <SolutionName>Autofac.Extras.DynamicProxy</SolutionName>
+    <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
+    <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>
+    <PackageDirectory>$([System.IO.Path]::Combine($(ArtifactDirectory),"packages"))</PackageDirectory>
+    <LogDirectory>$([System.IO.Path]::Combine($(ArtifactDirectory),"logs"))</LogDirectory>
+    <CoverageRunSettings>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),'build/Coverage.runsettings'))</CoverageRunSettings>
+    <BuildDateTime>$([System.DateTimeOffset]::UtcNow.ToString('yyyyMMddTHHmmssZ'))</BuildDateTime>
   </PropertyGroup>
-
-  <!-- Clean -->
+  <Choose>
+    <When Condition="'$(GITHUB_REF_NAME)'==''">
+      <PropertyGroup>
+        <Version>$(Version)-local</Version>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(GITHUB_REF_NAME)'=='master' Or $([System.Text.RegularExpressions.Regex]::IsMatch($(GITHUB_REF_NAME), `^v.+\..+\..+`))">
+      <PropertyGroup>
+        <Version>$(Version)</Version>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(GITHUB_REF_NAME)'=='develop'">
+      <PropertyGroup>
+        <Version>$(Version)-beta$(BuildDateTime)</Version>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Version>$(Version)-alpha$(BuildDateTime)</Version>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
-    <FilesToDelete Include="$(ArtifactsPath)/**/*.*" />
+    <CleanDirectory Include="$(ArtifactDirectory)" />
+    <SourceProject Include="$(MSBuildProjectDirectory)/src/**/*.csproj" />
+    <TestProject Include="$(MSBuildProjectDirectory)/test/**/*.csproj" />
+    <SolutionFile Include="$(SolutionName).sln" />
   </ItemGroup>
-
+  <Target Name="All">
+    <Message Text="****************************************" Importance="high" />
+    <Message Text="$(SolutionName) v$(Version)" Importance="high" />
+    <Message Text="$(Configuration) Configuration" Importance="high" />
+    <Message Text="$(BuildDateTime)" Importance="high" />
+    <Message Text="****************************************" Importance="high" />
+    <CallTarget Targets="Clean;Compile;Test;Package" />
+  </Target>
   <Target Name="Clean">
-    <Delete Files="@(FilesToDelete)" />
-    <RemoveDir Directories="$(ArtifactsPath)" />
+    <RemoveDir Directories="@(CleanDirectory)" />
+    <RemoveDir Directories="%(SourceProject.RootDir)%(SourceProject.Directory)bin;%(SourceProject.RootDir)%(SourceProject.Directory)obj" />
+    <RemoveDir Directories="%(TestProject.RootDir)%(TestProject.Directory)bin;%(TestProject.RootDir)%(TestProject.Directory)obj" />
   </Target>
-
-  <!-- Build and pack -->
-  <Target Name="BuildPack" DependsOnTargets="Clean">
-    <Exec Command="dotnet build &quot;$(Solution)&quot; -c $(Configuration) -p:Version=$(PackageVersion) -warnaserror" />
-    <Exec Command="dotnet pack &quot;$(Solution)&quot; -c $(Configuration) -p:Version=$(PackageVersion) -o &quot;$(PackagesPath)&quot; --no-build -warnaserror" />
+  <Target Name="Compile">
+    <Exec Command="dotnet --info" />
+    <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
-
-  <!-- Test -->
-  <Target Name="Test" DependsOnTargets="BuildPack">
-    <ItemGroup>
-      <TestProjects Include="$(MSBuildThisFileDirectory)test/**/*Test.csproj" />
-    </ItemGroup>
-    <PropertyGroup>
-      <TestCounter>0</TestCounter>
-    </PropertyGroup>
-    <Exec Command="dotnet test &quot;%(TestProjects.FullPath)&quot; -c $(Configuration) --no-build --collect &quot;XPlat Code Coverage&quot; --settings:&quot;$(MSBuildThisFileDirectory)build/Coverage.runsettings&quot; --results-directory &quot;$(LogsPath)/%(TestProjects.Filename)&quot; -l:trx" />
+  <Target Name="Package">
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
-
-  <!-- Main build target -->
-  <Target Name="Build" DependsOnTargets="Test" />
+  <Target Name="Test">
+    <MakeDir Directories="$(LogDirectory)" />
+    <Exec Command="dotnet test &quot;%(TestProject.Identity)&quot; -c $(Configuration) --results-directory &quot;$(LogDirectory)&quot; --logger:trx /p:Version=$(Version) --collect:&quot;XPlat Code Coverage&quot; --settings &quot;$(CoverageRunSettings)&quot;" />
+  </Target>
 </Project>

--- a/src/Autofac.Extras.DynamicProxy/InterceptAttribute.cs
+++ b/src/Autofac.Extras.DynamicProxy/InterceptAttribute.cs
@@ -10,16 +10,11 @@ namespace Autofac.Extras.DynamicProxy;
 /// Indicates that a type should be intercepted.
 /// </summary>
 [ExcludeFromCodeCoverage]
-[SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes")]
-[SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments")]
+[SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "Attribute is unsealed to allow derived types to provide additional interception metadata.")]
+[SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Constructor arguments are transformed into Service instances and exposed through InterceptorService property.")]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
 public class InterceptAttribute : Attribute
 {
-    /// <summary>
-    /// Gets the interceptor service.
-    /// </summary>
-    public Service InterceptorService { get; private set; }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="InterceptAttribute"/> class.
     /// </summary>
@@ -48,5 +43,13 @@ public class InterceptAttribute : Attribute
     public InterceptAttribute(Type interceptorServiceType)
         : this(new TypedService(interceptorServiceType))
     {
+    }
+
+    /// <summary>
+    /// Gets the interceptor service.
+    /// </summary>
+    public Service InterceptorService
+    {
+        get; private set;
     }
 }

--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -20,9 +20,9 @@ public static class RegistrationExtensions
 
     private const string AttributeInterceptorsPropertyName = "Autofac.Extras.DynamicProxy.RegistrationExtensions.AttributeInterceptorsPropertyName";
 
-    private static readonly IEnumerable<Service> EmptyServices = Enumerable.Empty<Service>();
+    private static readonly IEnumerable<Service> _emptyServices = Enumerable.Empty<Service>();
 
-    private static readonly ProxyGenerator ProxyGenerator = new();
+    private static readonly ProxyGenerator _proxyGenerator = new();
 
     /// <summary>
     /// Enable class interception on the target type. Interceptors will be determined
@@ -105,7 +105,7 @@ public static class RegistrationExtensions
         }
 
         registration.ActivatorData.ImplementationType =
-            ProxyGenerator.ProxyBuilder.CreateClassProxyType(
+            _proxyGenerator.ProxyBuilder.CreateClassProxyType(
                 registration.ActivatorData.ImplementationType,
                 additionalInterfaces ?? Type.EmptyTypes,
                 options);
@@ -116,7 +116,7 @@ public static class RegistrationExtensions
         registration.OnPreparing(e =>
         {
             var proxyParameters = new List<Parameter>();
-            int index = 0;
+            var index = 0;
 
             if (options.HasMixins)
             {
@@ -187,8 +187,8 @@ public static class RegistrationExtensions
                 .ToArray();
 
             ctx.Instance = options == null
-                ? ProxyGenerator.CreateInterfaceProxyWithTarget(theInterface, interfaces, ctx.Instance, interceptors)
-                : ProxyGenerator.CreateInterfaceProxyWithTarget(theInterface, interfaces, ctx.Instance, options, interceptors);
+                ? _proxyGenerator.CreateInterfaceProxyWithTarget(theInterface, interfaces, ctx.Instance, interceptors)
+                : _proxyGenerator.CreateInterfaceProxyWithTarget(theInterface, interfaces, ctx.Instance, options, interceptors);
         }));
 
         return registration;
@@ -287,7 +287,7 @@ public static class RegistrationExtensions
         IEnumerable<Service> interceptorServices,
         string metadataKey)
     {
-        if (builder.RegistrationData.Metadata.TryGetValue(metadataKey, out object? existing) && existing is IEnumerable<Service> existingServices)
+        if (builder.RegistrationData.Metadata.TryGetValue(metadataKey, out var existing) && existing is IEnumerable<Service> existingServices)
         {
             builder.RegistrationData.Metadata[metadataKey] =
                 existingServices.Concat(interceptorServices).Distinct();
@@ -300,9 +300,9 @@ public static class RegistrationExtensions
 
     private static IEnumerable<Service> GetInterceptorServices(IComponentRegistration registration, Type implType)
     {
-        var result = EmptyServices;
+        var result = _emptyServices;
 
-        if (registration.Metadata.TryGetValue(InterceptorsPropertyName, out object? services) && services is IEnumerable<Service> existingPropertyServices)
+        if (registration.Metadata.TryGetValue(InterceptorsPropertyName, out var services) && services is IEnumerable<Service> existingPropertyServices)
         {
             result = result.Concat(existingPropertyServices);
         }

--- a/test/Autofac.Extras.DynamicProxy.Test/AttributedInterfaceInterceptionFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/AttributedInterfaceInterceptionFixture.cs
@@ -59,7 +59,10 @@ public class AttributedInterfaceInterceptionFixture
             Value = 10;
         }
 
-        public int Value { get; private set; }
+        public int Value
+        {
+            get; private set;
+        }
 
         public int GetValueByMethod()
         {

--- a/test/Autofac.Extras.DynamicProxy.Test/AttributedInterfaceInterceptionWithOptionsFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/AttributedInterfaceInterceptionWithOptionsFixture.cs
@@ -79,9 +79,15 @@ public class AttributedInterfaceInterceptionWithOptionsFixture
             FirstValue = SecondValue = 10;
         }
 
-        public int FirstValue { get; private set; }
+        public int FirstValue
+        {
+            get; private set;
+        }
 
-        public int SecondValue { get; private set; }
+        public int SecondValue
+        {
+            get; private set;
+        }
 
         public int GetFirstValueByMethod()
         {

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsFixture.cs
@@ -83,13 +83,13 @@ public class ClassInterceptorsFixture
 
         var container = builder.Build();
 
-        const int i = 123;
+        const int I = 123;
 
         using (var scope = container.BeginLifetimeScope())
         {
             var mgr = scope.Resolve<ClassWithDelegateFactory>();
-            var byFunc = mgr.CreateByFunc(i);
-            var byDelegate = mgr.CreateByDelegate(i);
+            var byFunc = mgr.CreateByFunc(I);
+            var byDelegate = mgr.CreateByDelegate(I);
 
             Assert.Equal(byFunc.I, byDelegate.I);
         }
@@ -129,7 +129,10 @@ public class ClassInterceptorsFixture
             Value = i;
         }
 
-        public int Value { get; set; }
+        public int Value
+        {
+            get; set;
+        }
 
         public virtual int GetValueByMethod()
         {
@@ -144,7 +147,10 @@ public class ClassInterceptorsFixture
             Value = i;
         }
 
-        public int Value { get; set; }
+        public int Value
+        {
+            get; set;
+        }
 
         public virtual int GetValueByMethod()
         {
@@ -157,7 +163,10 @@ public class ClassInterceptorsFixture
     {
         public delegate ClassWithDelegate Factory(int i);
 
-        public int I { get; set; }
+        public int I
+        {
+            get; set;
+        }
 
         public ClassWithDelegate(int i)
         {
@@ -167,9 +176,15 @@ public class ClassInterceptorsFixture
 
     public class ClassWithDelegateFactory
     {
-        public Func<int, ClassWithDelegate> ObjectFuncFactory { get; set; }
+        public Func<int, ClassWithDelegate> ObjectFuncFactory
+        {
+            get; set;
+        }
 
-        public ClassWithDelegate.Factory ObjectDelegateFactory { get; set; }
+        public ClassWithDelegate.Factory ObjectDelegateFactory
+        {
+            get; set;
+        }
 
         public virtual ClassWithDelegate CreateByFunc(int i)
         {

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionsFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionsFixture.cs
@@ -10,7 +10,10 @@ public class ClassInterceptorsWithOptionsFixture
 {
     public interface ILazyLoadMixin
     {
-        bool IsLoaded { get; }
+        bool IsLoaded
+        {
+            get;
+        }
     }
 
     [Fact]
@@ -24,7 +27,7 @@ public class ClassInterceptorsWithOptionsFixture
         builder.RegisterType<AddOneInterceptor>();
         builder.RegisterType<AddTenInterceptor>();
         var container = builder.Build();
-        int i = 10;
+        var i = 10;
         var cpt = container.Resolve<HasAttributeInterceptors>(TypedParameter.From(i));
 
         var loaded = cpt as ILazyLoadMixin;
@@ -42,7 +45,7 @@ public class ClassInterceptorsWithOptionsFixture
         builder.RegisterType<AddOneInterceptor>();
         builder.RegisterType<AddTenInterceptor>();
         var container = builder.Build();
-        int i = 10;
+        var i = 10;
         var cpt = container.Resolve<HasAttributeInterceptors>(TypedParameter.From(i));
 
         Assert.Equal(i + 1, cpt.GetFirstValueByMethod());
@@ -59,7 +62,7 @@ public class ClassInterceptorsWithOptionsFixture
         builder.RegisterType<AddOneInterceptor>();
         builder.RegisterType<AddTenInterceptor>();
         var container = builder.Build();
-        int i = 10;
+        var i = 10;
         var cpt = container.Resolve<HasAttributeInterceptors>(TypedParameter.From(i));
 
         Assert.Equal(i, cpt.GetFirstValueByMethod());
@@ -99,9 +102,15 @@ public class ClassInterceptorsWithOptionsFixture
             FirstValue = SecondValue = i;
         }
 
-        public int FirstValue { get; set; }
+        public int FirstValue
+        {
+            get; set;
+        }
 
-        public int SecondValue { get; set; }
+        public int SecondValue
+        {
+            get; set;
+        }
 
         public virtual int GetFirstValueByMethod()
         {
@@ -121,9 +130,15 @@ public class ClassInterceptorsWithOptionsFixture
             FirstValue = SecondValue = i;
         }
 
-        public int FirstValue { get; set; }
+        public int FirstValue
+        {
+            get; set;
+        }
 
-        public int SecondValue { get; set; }
+        public int SecondValue
+        {
+            get; set;
+        }
 
         public virtual int GetFirstValueByMethod()
         {

--- a/test/Autofac.Extras.DynamicProxy.Test/InterceptorsChosenByMetadataFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/InterceptorsChosenByMetadataFixture.cs
@@ -33,7 +33,10 @@ public class InterceptorsChosenByMetadataFixture
             VisitCount = 10;
         }
 
-        private int VisitCount { get; set; }
+        private int VisitCount
+        {
+            get; set;
+        }
 
         public int GetVisitCount()
         {

--- a/test/Autofac.Extras.DynamicProxy.Test/InterceptorsChosenByMetadataWithOptionsFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/InterceptorsChosenByMetadataWithOptionsFixture.cs
@@ -85,9 +85,15 @@ public class InterceptorsChosenByMetadataWithOptionsFixture
             UniqueVisitorCount = 6;
         }
 
-        private int UniqueVisitorCount { get; set; }
+        private int UniqueVisitorCount
+        {
+            get; set;
+        }
 
-        private int VisitCount { get; set; }
+        private int VisitCount
+        {
+            get; set;
+        }
 
         public int GetUniqueVisitorCount()
         {

--- a/test/Autofac.Extras.DynamicProxy.Test/InterfaceInterceptionWithPropertyInjectionFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/InterfaceInterceptionWithPropertyInjectionFixture.cs
@@ -62,7 +62,10 @@ public class InterfaceInterceptionWithPropertyInjectionFixture
 
     public class InterceptableWithProperty : IPublicInterface
     {
-        public OtherService Service { get; set; }
+        public OtherService Service
+        {
+            get; set;
+        }
 
         public OtherService GetServiceProperty() => Service;
 


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Rewrite `default.proj` to match standard template (was using non-standard structure)
- Apply `dotnet format` code formatting
- Fix SA1201 member ordering and SA1404 SuppressMessage justifications

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes