### PR TITLE
Add conditional interception via type predicate (#42)

### DIFF
--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -40,6 +40,28 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
+    /// Enable class interception on the target type, conditionally based on the
+    /// implementation type. Interceptors will be determined via Intercept attributes
+    /// on the class or added with InterceptedBy(). Only virtual methods can be
+    /// intercepted this way.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">Registration to apply interception to.</param>
+    /// <param name="shouldIntercept">
+    /// A predicate, evaluated against each candidate implementation type, that
+    /// determines whether interception is applied. Types for which the predicate
+    /// returns <see langword="false" /> are registered without interception.
+    /// </param>
+    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    public static IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TRegistrationStyle>(
+        this IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> registration,
+        Func<Type, bool> shouldIntercept)
+    {
+        return EnableClassInterceptors(registration, ProxyGenerationOptions.Default, shouldIntercept);
+    }
+
+    /// <summary>
     /// Enable class interception on the target type. Interceptors will be determined
     /// via Intercept attributes on the class or added with InterceptedBy().
     /// Only virtual methods can be intercepted this way.
@@ -54,6 +76,30 @@ public static class RegistrationExtensions
         where TConcreteReflectionActivatorData : ConcreteReflectionActivatorData
     {
         return EnableClassInterceptors(registration, ProxyGenerationOptions.Default);
+    }
+
+    /// <summary>
+    /// Enable class interception on the target type, conditionally based on the
+    /// implementation type. Interceptors will be determined via Intercept attributes
+    /// on the class or added with InterceptedBy(). Only virtual methods can be
+    /// intercepted this way.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TConcreteReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">Registration to apply interception to.</param>
+    /// <param name="shouldIntercept">
+    /// A predicate, evaluated against the implementation type, that determines
+    /// whether interception is applied. When the predicate returns
+    /// <see langword="false" /> the type is registered without interception.
+    /// </param>
+    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    public static IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle>(
+        this IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> registration,
+        Func<Type, bool> shouldIntercept)
+        where TConcreteReflectionActivatorData : ConcreteReflectionActivatorData
+    {
+        return EnableClassInterceptors(registration, ProxyGenerationOptions.Default, shouldIntercept);
     }
 
     /// <summary>
@@ -72,12 +118,38 @@ public static class RegistrationExtensions
         ProxyGenerationOptions options,
         params Type[] additionalInterfaces)
     {
+        return EnableClassInterceptors(registration, options, null, additionalInterfaces);
+    }
+
+    /// <summary>
+    /// Enable class interception on the target type. Interceptors will be determined
+    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Only virtual methods can be intercepted this way.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">Registration to apply interception to.</param>
+    /// <param name="options">Proxy generation options to apply.</param>
+    /// <param name="shouldIntercept">
+    /// An optional predicate, evaluated against each candidate implementation type,
+    /// that determines whether interception is applied. Types for which the predicate
+    /// returns <see langword="false" /> are registered without interception. When
+    /// <see langword="null" /> all types are intercepted.
+    /// </param>
+    /// <param name="additionalInterfaces">Additional interface types. Calls to their members will be proxied as well.</param>
+    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    public static IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TRegistrationStyle>(
+        this IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> registration,
+        ProxyGenerationOptions options,
+        Func<Type, bool>? shouldIntercept,
+        params Type[] additionalInterfaces)
+    {
         if (registration == null)
         {
             throw new ArgumentNullException(nameof(registration));
         }
 
-        registration.ActivatorData.ConfigurationActions.Add((t, rb) => rb.EnableClassInterceptors(options, additionalInterfaces));
+        registration.ActivatorData.ConfigurationActions.Add((t, rb) => rb.EnableClassInterceptors(options, shouldIntercept, additionalInterfaces));
         return registration;
     }
 
@@ -99,9 +171,45 @@ public static class RegistrationExtensions
         params Type[] additionalInterfaces)
         where TConcreteReflectionActivatorData : ConcreteReflectionActivatorData
     {
+        return EnableClassInterceptors(registration, options, null, additionalInterfaces);
+    }
+
+    /// <summary>
+    /// Enable class interception on the target type. Interceptors will be determined
+    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Only virtual methods can be intercepted this way.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TConcreteReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">Registration to apply interception to.</param>
+    /// <param name="options">Proxy generation options to apply.</param>
+    /// <param name="shouldIntercept">
+    /// An optional predicate, evaluated against the implementation type, that
+    /// determines whether interception is applied. When the predicate returns
+    /// <see langword="false" /> the type is registered without interception. When
+    /// <see langword="null" /> the type is intercepted.
+    /// </param>
+    /// <param name="additionalInterfaces">Additional interface types. Calls to their members will be proxied as well.</param>
+    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    public static IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle>(
+        this IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> registration,
+        ProxyGenerationOptions options,
+        Func<Type, bool>? shouldIntercept,
+        params Type[] additionalInterfaces)
+        where TConcreteReflectionActivatorData : ConcreteReflectionActivatorData
+    {
         if (registration == null)
         {
             throw new ArgumentNullException(nameof(registration));
+        }
+
+        // Class interception rewrites the implementation type to a proxy subclass
+        // at registration time, so the decision to intercept is made here, per type.
+        // When the predicate rejects the type the registration is left untouched.
+        if (shouldIntercept != null && !shouldIntercept(registration.ActivatorData.ImplementationType))
+        {
+            return registration;
         }
 
         registration.ActivatorData.ImplementationType =
@@ -155,6 +263,52 @@ public static class RegistrationExtensions
     public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> EnableInterfaceInterceptors<TLimit, TActivatorData, TSingleRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration, ProxyGenerationOptions? options = null)
     {
+        return EnableInterfaceInterceptors(registration, options, null);
+    }
+
+    /// <summary>
+    /// Enable interface interception on the target type, conditionally based on the
+    /// resolved implementation type. Interceptors will be determined via Intercept
+    /// attributes on the class or interface, or added with InterceptedBy() calls.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">Registration to apply interception to.</param>
+    /// <param name="shouldIntercept">
+    /// A predicate, evaluated against the resolved implementation type, that
+    /// determines whether interception is applied. When the predicate returns
+    /// <see langword="false" /> the resolved instance is returned without a proxy.
+    /// </param>
+    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> EnableInterfaceInterceptors<TLimit, TActivatorData, TSingleRegistrationStyle>(
+        this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+        Func<Type, bool> shouldIntercept)
+    {
+        return EnableInterfaceInterceptors(registration, null, shouldIntercept);
+    }
+
+    /// <summary>
+    /// Enable interface interception on the target type, conditionally based on the
+    /// resolved implementation type. Interceptors will be determined via Intercept
+    /// attributes on the class or interface, or added with InterceptedBy() calls.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">Registration to apply interception to.</param>
+    /// <param name="options">Proxy generation options to apply.</param>
+    /// <param name="shouldIntercept">
+    /// A predicate, evaluated against the resolved implementation type, that
+    /// determines whether interception is applied. When the predicate returns
+    /// <see langword="false" /> the resolved instance is returned without a proxy.
+    /// </param>
+    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> EnableInterfaceInterceptors<TLimit, TActivatorData, TSingleRegistrationStyle>(
+        this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+        ProxyGenerationOptions? options,
+        Func<Type, bool>? shouldIntercept)
+    {
         if (registration == null)
         {
             throw new ArgumentNullException(nameof(registration));
@@ -164,11 +318,21 @@ public static class RegistrationExtensions
         {
             next(ctx);
 
+            // The instance won't ever _practically_ be null by the time it gets here.
+            var implementationType = ctx.Instance!.GetType();
+
+            // Interface interception happens at resolve time, so the predicate is
+            // evaluated against the actual implementation type being returned. When
+            // it rejects the type the instance is returned unproxied; the
+            // interface-only guard is also skipped because no proxy is created.
+            if (shouldIntercept != null && !shouldIntercept(implementationType))
+            {
+                return;
+            }
+
             EnsureInterfaceInterceptionApplies(ctx.Service, ctx.Registration);
 
-            // The instance won't ever _practically_ be null by the time it gets here.
-            var proxiedInterfaces = ctx.Instance!
-                .GetType()
+            var proxiedInterfaces = implementationType
                 .GetInterfaces()
                 .Where(ProxyUtil.IsAccessible)
                 .ToArray();
@@ -181,7 +345,7 @@ public static class RegistrationExtensions
             var theInterface = proxiedInterfaces[0];
             var interfaces = proxiedInterfaces.Skip(1).ToArray();
 
-            var interceptors = GetInterceptorServices(ctx.Registration, ctx.Instance.GetType())
+            var interceptors = GetInterceptorServices(ctx.Registration, implementationType)
                 .Select(s => ctx.ResolveService(s))
                 .Cast<IInterceptor>()
                 .ToArray();

--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -25,14 +25,24 @@ public static class RegistrationExtensions
     private static readonly ProxyGenerator _proxyGenerator = new();
 
     /// <summary>
-    /// Enable class interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Enable class interception on the target type. Interceptors will be
+    /// determined via <see cref="InterceptAttribute"/> on the class or added
+    /// with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> registration)
     {
@@ -41,19 +51,29 @@ public static class RegistrationExtensions
 
     /// <summary>
     /// Enable class interception on the target type, conditionally based on the
-    /// implementation type. Interceptors will be determined via Intercept attributes
-    /// on the class or added with InterceptedBy(). Only virtual methods can be
-    /// intercepted this way.
+    /// implementation type. Interceptors will be determined via
+    /// <see cref="InterceptAttribute"/> on the class or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
+    /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
     /// <param name="shouldIntercept">
     /// A predicate, evaluated against each candidate implementation type, that
-    /// determines whether interception is applied. Types for which the predicate
-    /// returns <see langword="false" /> are registered without interception.
+    /// determines whether interception is applied. Types for which the
+    /// predicate returns <see langword="false" /> are registered without
+    /// interception.
     /// </param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> registration,
         Func<Type, bool> shouldIntercept)
@@ -62,15 +82,27 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable class interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Enable class interception on the target type. Interceptors will be
+    /// determined via <see cref="InterceptAttribute"/> on the class or added
+    /// with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TConcreteReflectionActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TConcreteReflectionActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> registration)
         where TConcreteReflectionActivatorData : ConcreteReflectionActivatorData
@@ -80,20 +112,31 @@ public static class RegistrationExtensions
 
     /// <summary>
     /// Enable class interception on the target type, conditionally based on the
-    /// implementation type. Interceptors will be determined via Intercept attributes
-    /// on the class or added with InterceptedBy(). Only virtual methods can be
-    /// intercepted this way.
+    /// implementation type. Interceptors will be determined via
+    /// <see cref="InterceptAttribute"/> on the class or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
+    /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TConcreteReflectionActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TConcreteReflectionActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
     /// <param name="shouldIntercept">
     /// A predicate, evaluated against the implementation type, that determines
     /// whether interception is applied. When the predicate returns
     /// <see langword="false" /> the type is registered without interception.
     /// </param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> registration,
         Func<Type, bool> shouldIntercept)
@@ -103,16 +146,30 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable class interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Enable class interception on the target type with specific options and
+    /// additional interfaces. Interceptors will be determined via
+    /// <see cref="InterceptAttribute"/> on the class or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <param name="options">Proxy generation options to apply.</param>
-    /// <param name="additionalInterfaces">Additional interface types. Calls to their members will be proxied as well.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="options">
+    /// Proxy generation options to apply.
+    /// </param>
+    /// <param name="additionalInterfaces">
+    /// Additional interface types. Calls to their members will be proxied as well.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, ScanningActivatorData, TRegistrationStyle> registration,
         ProxyGenerationOptions options,
@@ -122,14 +179,25 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable class interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Enable class interception on the target type, conditionally based on the
+    /// implementation type, with specific options and additional interfaces.
+    /// Interceptors will be determined via <see cref="InterceptAttribute"/> on
+    /// the class or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <param name="options">Proxy generation options to apply.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="options">
+    /// Proxy generation options to apply.
+    /// </param>
     /// <param name="shouldIntercept">
     /// An optional predicate, evaluated against each candidate implementation type,
     /// that determines whether interception is applied. Types for which the predicate
@@ -154,16 +222,30 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable class interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Enable class interception on the target type with specific options and
+    /// additional interfaces. Interceptors will be determined via
+    /// <see cref="InterceptAttribute"/> on the class or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TConcreteReflectionActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <param name="options">Proxy generation options to apply.</param>
-    /// <param name="additionalInterfaces">Additional interface types. Calls to their members will be proxied as well.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TConcreteReflectionActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="options">
+    /// Proxy generation options to apply.
+    /// </param>
+    /// <param name="additionalInterfaces">
+    /// Additional interface types. Calls to their members will be proxied as well.
+    /// </param>
     /// <returns>Registration builder allowing the registration to be configured.</returns>
     public static IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> registration,
@@ -175,23 +257,40 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable class interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or added with InterceptedBy().
+    /// Enable class interception on the target type, conditionally based on the
+    /// implementation type, with specific options and additional interfaces.
+    /// Interceptors will be determined via <see cref="InterceptAttribute"/> on
+    /// the class or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// Only virtual methods can be intercepted this way.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TConcreteReflectionActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <param name="options">Proxy generation options to apply.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TConcreteReflectionActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="options">
+    /// Proxy generation options to apply.
+    /// </param>
     /// <param name="shouldIntercept">
     /// An optional predicate, evaluated against the implementation type, that
     /// determines whether interception is applied. When the predicate returns
     /// <see langword="false" /> the type is registered without interception. When
     /// <see langword="null" /> the type is intercepted.
     /// </param>
-    /// <param name="additionalInterfaces">Additional interface types. Calls to their members will be proxied as well.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <param name="additionalInterfaces">
+    /// Additional interface types. Calls to their members will be proxied as well.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> EnableClassInterceptors<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TConcreteReflectionActivatorData, TRegistrationStyle> registration,
         ProxyGenerationOptions options,
@@ -251,15 +350,29 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable interface interception on the target type. Interceptors will be determined
-    /// via Intercept attributes on the class or interface, or added with InterceptedBy() calls.
+    /// Enable interface interception on the target type. Interceptors will be
+    /// determined via <see cref="InterceptAttribute"/> on the class or
+    /// interface, or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <param name="options">Proxy generation options to apply.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="options">
+    /// Proxy generation options to apply.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> EnableInterfaceInterceptors<TLimit, TActivatorData, TSingleRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration, ProxyGenerationOptions? options = null)
     {
@@ -267,20 +380,28 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable interface interception on the target type, conditionally based on the
-    /// resolved implementation type. Interceptors will be determined via Intercept
-    /// attributes on the class or interface, or added with InterceptedBy() calls.
+    /// Enable interface interception on the target type, conditionally based on
+    /// the resolved implementation type. Interceptors will be determined via
+    /// <see cref="InterceptAttribute"/> on the class or interface, or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">
+    /// Registration style.</typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
     /// <param name="shouldIntercept">
     /// A predicate, evaluated against the resolved implementation type, that
     /// determines whether interception is applied. When the predicate returns
     /// <see langword="false" /> the resolved instance is returned without a proxy.
     /// </param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> EnableInterfaceInterceptors<TLimit, TActivatorData, TSingleRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
         Func<Type, bool> shouldIntercept)
@@ -289,21 +410,35 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Enable interface interception on the target type, conditionally based on the
-    /// resolved implementation type. Interceptors will be determined via Intercept
-    /// attributes on the class or interface, or added with InterceptedBy() calls.
+    /// Enable interface interception on the target type, conditionally based on
+    /// the resolved implementation type, with specific options. Interceptors
+    /// will be determined via <see cref="InterceptAttribute"/> on the class or
+    /// interface, or added with
+    /// <see cref="InterceptedBy{TLimit, TActivatorData, TStyle}(IRegistrationBuilder{TLimit, TActivatorData, TStyle},string[])"/>.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-    /// <param name="registration">Registration to apply interception to.</param>
-    /// <param name="options">Proxy generation options to apply.</param>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="registration">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="options">
+    /// Proxy generation options to apply.
+    /// </param>
     /// <param name="shouldIntercept">
     /// A predicate, evaluated against the resolved implementation type, that
     /// determines whether interception is applied. When the predicate returns
     /// <see langword="false" /> the resolved instance is returned without a proxy.
     /// </param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
     public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> EnableInterfaceInterceptors<TLimit, TActivatorData, TSingleRegistrationStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
         ProxyGenerationOptions? options,
@@ -359,15 +494,29 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Allows a list of interceptor services to be assigned to the registration.
+    /// Assigns a list of interceptor services to a registration by service.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TStyle">Registration style.</typeparam>
-    /// <param name="builder">Registration to apply interception to.</param>
-    /// <param name="interceptorServices">The interceptor services.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="interceptorServices"/>.</exception>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="builder">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="interceptorServices">
+    /// The interceptor services.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder"/> or <paramref name="interceptorServices"/> is <see langword="null"/>.
+    /// </exception>
     public static IRegistrationBuilder<TLimit, TActivatorData, TStyle> InterceptedBy<TLimit, TActivatorData, TStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TStyle> builder,
         params Service[] interceptorServices)
@@ -388,15 +537,29 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Allows a list of interceptor services to be assigned to the registration.
+    /// Assigns a list of interceptor services to a registration by name.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TStyle">Registration style.</typeparam>
-    /// <param name="builder">Registration to apply interception to.</param>
-    /// <param name="interceptorServiceNames">The names of the interceptor services.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="interceptorServiceNames"/>.</exception>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="builder">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="interceptorServiceNames">
+    /// The names of the interceptor services.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder"/> or <paramref name="interceptorServiceNames"/> is <see langword="null"/>.
+    /// </exception>
     public static IRegistrationBuilder<TLimit, TActivatorData, TStyle> InterceptedBy<TLimit, TActivatorData, TStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TStyle> builder,
         params string[] interceptorServiceNames)
@@ -410,15 +573,30 @@ public static class RegistrationExtensions
     }
 
     /// <summary>
-    /// Allows a list of interceptor services to be assigned to the registration.
+    /// Assigns a list of interceptor services to a registration by interceptor
+    /// type.
     /// </summary>
-    /// <typeparam name="TLimit">Registration limit type.</typeparam>
-    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-    /// <typeparam name="TStyle">Registration style.</typeparam>
-    /// <param name="builder">Registration to apply interception to.</param>
-    /// <param name="interceptorServiceTypes">The types of the interceptor services.</param>
-    /// <returns>Registration builder allowing the registration to be configured.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="builder"/> or <paramref name="interceptorServiceTypes"/>.</exception>
+    /// <typeparam name="TLimit">
+    /// Registration limit type.
+    /// </typeparam>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type.
+    /// </typeparam>
+    /// <typeparam name="TStyle">
+    /// Registration style.
+    /// </typeparam>
+    /// <param name="builder">
+    /// Registration to apply interception to.
+    /// </param>
+    /// <param name="interceptorServiceTypes">
+    /// The types of the interceptor services.
+    /// </param>
+    /// <returns>
+    /// Registration builder allowing the registration to be configured.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder"/> or <paramref name="interceptorServiceTypes"/> is <see langword="null"/>.
+    /// </exception>
     public static IRegistrationBuilder<TLimit, TActivatorData, TStyle> InterceptedBy<TLimit, TActivatorData, TStyle>(
         this IRegistrationBuilder<TLimit, TActivatorData, TStyle> builder,
         params Type[] interceptorServiceTypes)

--- a/test/Autofac.Extras.DynamicProxy.Test/ConditionalInterceptionFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ConditionalInterceptionFixture.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Builder;
+using Autofac.Features.Scanning;
+using Castle.DynamicProxy;
+using IInvocation = Castle.DynamicProxy.IInvocation;
+
+namespace Autofac.Extras.DynamicProxy.Test;
+
+public class ConditionalInterceptionFixture
+{
+    [Fact]
+    public void NullRegistration_Throws()
+    {
+        IRegistrationBuilder<Intercepted, ConcreteReflectionActivatorData, SingleRegistrationStyle> concrete = null!;
+        IRegistrationBuilder<Intercepted, ScanningActivatorData, SingleRegistrationStyle> scanning = null!;
+        Func<Type, bool> predicate = _ => true;
+
+        Assert.Throws<ArgumentNullException>(() => concrete.EnableInterfaceInterceptors(predicate));
+        Assert.Throws<ArgumentNullException>(() => concrete.EnableClassInterceptors(predicate));
+        Assert.Throws<ArgumentNullException>(() => scanning.EnableClassInterceptors(predicate));
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class InterceptMeAttribute : Attribute
+    {
+    }
+
+    public interface IPublicInterface
+    {
+        string PublicMethod();
+    }
+
+    [Fact]
+    public void InterfaceInterception_AppliesProxyWhenPredicateMatches()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<StringMethodInterceptor>();
+        builder
+            .RegisterType<Intercepted>()
+            .EnableInterfaceInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+            .InterceptedBy(typeof(StringMethodInterceptor))
+            .As<IPublicInterface>();
+        var container = builder.Build();
+
+        var obj = container.Resolve<IPublicInterface>();
+
+        Assert.Equal("intercepted-PublicMethod", obj.PublicMethod());
+    }
+
+    [Fact]
+    public void InterfaceInterception_SkipsProxyWhenPredicateDoesNotMatch()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<StringMethodInterceptor>();
+        builder
+            .RegisterType<NotIntercepted>()
+            .EnableInterfaceInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+            .InterceptedBy(typeof(StringMethodInterceptor))
+            .As<IPublicInterface>();
+        var container = builder.Build();
+
+        var obj = container.Resolve<IPublicInterface>();
+
+        // Predicate returns false, so the raw instance is returned without a proxy.
+        Assert.Equal("PublicMethod", obj.PublicMethod());
+        Assert.IsType<NotIntercepted>(obj);
+    }
+
+    [Fact]
+    public void InterfaceInterception_PredicateAppliesPerScannedType()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<StringMethodInterceptor>();
+        builder
+            .RegisterAssemblyTypes(typeof(ConditionalInterceptionFixture).Assembly)
+            .Where(t => t == typeof(Intercepted) || t == typeof(NotIntercepted))
+            .As<IPublicInterface>()
+            .EnableInterfaceInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+            .InterceptedBy(typeof(StringMethodInterceptor));
+        var container = builder.Build();
+
+        var all = container.Resolve<IEnumerable<IPublicInterface>>().ToList();
+
+        // The attributed type is proxied; the other is returned untouched.
+        Assert.Contains(all, o => o.PublicMethod() == "intercepted-PublicMethod");
+        Assert.Contains(all, o => o.PublicMethod() == "PublicMethod");
+    }
+
+    [Fact]
+    public void ClassInterception_AppliesProxyWhenPredicateMatches()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<StringMethodInterceptor>();
+        builder
+            .RegisterType<InterceptedClass>()
+            .EnableClassInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+            .InterceptedBy(typeof(StringMethodInterceptor));
+        var container = builder.Build();
+
+        var obj = container.Resolve<InterceptedClass>();
+
+        Assert.Equal("intercepted-VirtualMethod", obj.VirtualMethod());
+    }
+
+    [Fact]
+    public void ClassInterception_SkipsProxyWhenPredicateDoesNotMatch()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<StringMethodInterceptor>();
+        builder
+            .RegisterType<NotInterceptedClass>()
+            .EnableClassInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+            .InterceptedBy(typeof(StringMethodInterceptor));
+        var container = builder.Build();
+
+        var obj = container.Resolve<NotInterceptedClass>();
+
+        // Predicate returns false, so the type is registered without a proxy.
+        Assert.Equal("VirtualMethod", obj.VirtualMethod());
+        Assert.Same(typeof(NotInterceptedClass), obj.GetType());
+    }
+
+    [Fact]
+    public void ClassInterception_PredicateAppliesPerScannedType()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<StringMethodInterceptor>();
+        builder
+            .RegisterAssemblyTypes(typeof(ConditionalInterceptionFixture).Assembly)
+            .Where(t => t == typeof(InterceptedClass) || t == typeof(NotInterceptedClass))
+            .EnableClassInterceptors(t => t.IsDefined(typeof(InterceptMeAttribute), false))
+            .InterceptedBy(typeof(StringMethodInterceptor));
+        var container = builder.Build();
+
+        Assert.Equal("intercepted-VirtualMethod", container.Resolve<InterceptedClass>().VirtualMethod());
+        Assert.Equal("VirtualMethod", container.Resolve<NotInterceptedClass>().VirtualMethod());
+    }
+
+    [InterceptMe]
+    public class Intercepted : IPublicInterface
+    {
+        public string PublicMethod() => "PublicMethod";
+    }
+
+    public class NotIntercepted : IPublicInterface
+    {
+        public string PublicMethod() => "PublicMethod";
+    }
+
+    [InterceptMe]
+    public class InterceptedClass
+    {
+        public virtual string VirtualMethod() => "VirtualMethod";
+    }
+
+    public class NotInterceptedClass
+    {
+        public virtual string VirtualMethod() => "VirtualMethod";
+    }
+
+    private class StringMethodInterceptor : IInterceptor
+    {
+        public void Intercept(IInvocation invocation)
+        {
+            if (invocation.Method.ReturnType == typeof(string))
+            {
+                invocation.ReturnValue = "intercepted-" + invocation.Method.Name;
+            }
+            else
+            {
+                invocation.Proceed();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #42.

## Problem

There was no way to apply interception selectively. When using assembly scanning, `EnableClassInterceptors`/`EnableInterfaceInterceptors` applied interception to every scanned type, with no hook to intercept only some of them based on the type.

## Solution

Add a `shouldIntercept` predicate (`Func<Type, bool>`) to both `EnableClassInterceptors` and `EnableInterfaceInterceptors`, evaluated against the implementation type. This matches the shape suggested on the issue:

```csharp
builder.RegisterAssemblyTypes(asm)
       .AsClosedTypesOf(typeof(ICommandHandler<,>))
       .EnableInterfaceInterceptors(t => t.IsDefined(typeof(AuditAttribute)))
       .InterceptedBy(typeof(LoggingInterceptor));
```

All new overloads are **additive** — every existing signature is unchanged, preserving binary compatibility (this is a strong-named assembly).

| Method | New overloads |
|---|---|
| `EnableInterfaceInterceptors` | `(Func<Type,bool>)` and `(ProxyGenerationOptions?, Func<Type,bool>?)` |
| `EnableClassInterceptors` (concrete & scanning) | `(Func<Type,bool>)` and `(ProxyGenerationOptions, Func<Type,bool>?, params Type[])` |

## Semantics

The predicate is evaluated at different times for the two styles, because they work differently:

- **Interface interception** is resolve-time middleware, so the predicate is evaluated against the resolved implementation type (`ctx.Instance.GetType()`). When it returns `false` the instance is returned without a proxy (and the interface-only guard is skipped, since no proxy is attempted).
- **Class interception** rewrites the implementation type to a proxy subclass at registration time, so the predicate is evaluated per type at registration. When it returns `false` the registration is left untouched (real type, no proxy). Per-instance conditionality is not possible for class interception by construction.

Both behaviors are covered by XML docs and code comments.

## Tests

New fixture `ConditionalInterceptionFixture` (7 tests):

- Applies / skips the proxy for both interface and class interception based on the predicate.
- Predicate applies per-type under assembly scanning for both styles.
- Null-registration guard for the new overloads.

Full suite green on net8.0 and net10.0; clean Release build (warnings-as-errors + analyzers) and `dotnet format` clean.