### PR TITLE
Add documenting tests for KeyFilter + class interception limitation (#56)

### DIFF
--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithAttributeFilteringFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithAttributeFilteringFixture.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Features.AttributeFilters;
+using Castle.DynamicProxy;
+
+namespace Autofac.Extras.DynamicProxy.Test;
+
+/// <summary>
+/// Documents the interaction between <c>WithAttributeFiltering</c> and class
+/// interception, including a known limitation tracked by
+/// <see href="https://github.com/autofac/Autofac.Extras.DynamicProxy/issues/56">issue #56</see>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>EnableClassInterceptors</c> rewrites the implementation type to a Castle
+/// DynamicProxy subclass, replicating the original constructor parameter
+/// attributes onto the proxy constructor. Castle reproduces an <b>enum</b>
+/// argument passed to an attribute parameter that is typed <see cref="object"/>
+/// (as <c>KeyFilterAttribute(object key)</c> is) using the enum's <b>underlying
+/// integer</b> type rather than the original enum type. As a result the key on
+/// the replicated <see cref="KeyFilterAttribute"/> no longer matches the
+/// registered keyed service, and filtering silently fails.
+/// </para>
+/// <para>
+/// This is an upstream Castle DynamicProxy bug tracked at
+/// <see href="https://github.com/castleproject/Core/issues/748">castleproject/Core#748</see>.
+/// It only affects non-string keys under class interception; string keys and
+/// interface interception are unaffected. The tests below pin the current
+/// behavior so we get a signal if/when the upstream behavior changes.
+/// </para>
+/// </remarks>
+public class ClassInterceptorsWithAttributeFilteringFixture
+{
+    public enum LoggerKey
+    {
+        First,
+        Second,
+    }
+
+    [Fact]
+    public void EnumKeyFilteringWorksWithoutInterception()
+    {
+        // Baseline: WithAttributeFiltering honors an enum [KeyFilter] when
+        // interception is NOT enabled.
+        var builder = new ContainerBuilder();
+        builder.Register(c => "first").Keyed<string>(LoggerKey.First);
+        builder.Register(c => "second").Keyed<string>(LoggerKey.Second);
+        builder.RegisterType<HasEnumKeyedParameter>().WithAttributeFiltering();
+        var container = builder.Build();
+
+        var resolved = container.Resolve<HasEnumKeyedParameter>();
+
+        Assert.Equal("first", resolved.Value);
+    }
+
+    [Fact]
+    public void EnumKeyFilteringIsNotHonoredWithClassInterception()
+    {
+        // KNOWN LIMITATION (issue #56 / castleproject/Core#748): with class
+        // interception the replicated [KeyFilter] loses its enum key type, so the
+        // filter no longer matches the keyed registration and the unkeyed
+        // fallback is injected instead of the "First" keyed value.
+        //
+        // This test documents the *current, incorrect* behavior. If it starts
+        // failing because "first" is resolved, Castle has likely fixed the
+        // underlying bug and this limitation (and the docs/comments) can be
+        // removed.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<NullInterceptor>();
+        builder.Register(c => "first").Keyed<string>(LoggerKey.First);
+        builder.Register(c => "fallback");
+        builder
+            .RegisterType<HasEnumKeyedParameter>()
+            .WithAttributeFiltering()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(NullInterceptor));
+        var container = builder.Build();
+
+        var resolved = container.Resolve<HasEnumKeyedParameter>();
+
+        Assert.Equal("fallback", resolved.Value);
+    }
+
+    [Fact]
+    public void StringKeyFilteringWorksWithClassInterception()
+    {
+        // WORKAROUND: a string key round-trips through the object-typed attribute
+        // parameter losslessly, so filtering works with class interception.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<NullInterceptor>();
+        builder.Register(c => "first").Keyed<string>("first-key");
+        builder.Register(c => "fallback");
+        builder
+            .RegisterType<HasStringKeyedParameter>()
+            .WithAttributeFiltering()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(NullInterceptor));
+        var container = builder.Build();
+
+        var resolved = container.Resolve<HasStringKeyedParameter>();
+
+        Assert.Equal("first", resolved.Value);
+    }
+
+    [Fact]
+    public void EnumKeyFilteringWorksWithInterfaceInterception()
+    {
+        // WORKAROUND: interface interception does not rewrite the constructor, so
+        // the original [KeyFilter] is read intact and the enum key matches.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<NullInterceptor>();
+        builder.Register(c => "first").Keyed<string>(LoggerKey.First);
+        builder.Register(c => "fallback");
+        builder
+            .RegisterType<HasEnumKeyedParameter>()
+            .WithAttributeFiltering()
+            .As<IHaveValue>()
+            .EnableInterfaceInterceptors()
+            .InterceptedBy(typeof(NullInterceptor));
+        var container = builder.Build();
+
+        var resolved = container.Resolve<IHaveValue>();
+
+        Assert.Equal("first", resolved.Value);
+    }
+
+    public interface IHaveValue
+    {
+        string Value
+        {
+            get;
+        }
+    }
+
+    public class HasEnumKeyedParameter : IHaveValue
+    {
+        public HasEnumKeyedParameter([KeyFilter(LoggerKey.First)] string value)
+        {
+            Value = value;
+        }
+
+        public virtual string Value
+        {
+            get;
+        }
+    }
+
+    public class HasStringKeyedParameter
+    {
+        public HasStringKeyedParameter([KeyFilter("first-key")] string value)
+        {
+            Value = value;
+        }
+
+        public virtual string Value
+        {
+            get;
+        }
+    }
+
+    private class NullInterceptor : IInterceptor
+    {
+        public void Intercept(IInvocation invocation)
+        {
+            invocation.Proceed();
+        }
+    }
+}


### PR DESCRIPTION
Relates to #56. Filed upstream as castleproject/Core#748.

## Background

Issue #56 reports that `[KeyFilter]` with an enum key is ignored when a type is registered with both `WithAttributeFiltering()` and `EnableClassInterceptors()`.

After investigation, the root cause is an **upstream Castle DynamicProxy bug**, not something in this library or in Autofac core:

- `EnableClassInterceptors` rewrites the implementation type to a Castle proxy subclass, replicating the original constructor parameter attributes onto the proxy constructor.
- `KeyFilterAttribute`'s constructor parameter is typed `object` (`KeyFilterAttribute(object key)`), so an **enum** key is boxed. Castle reproduces that boxed enum argument using the enum's **underlying integer** type rather than the original enum type.
- The replicated `KeyFilterAttribute.Key` ends up as boxed `(int)0` instead of e.g. `LoggerKey.First`, so core's `WithAttributeFiltering` looks up `new KeyedService((int)0, typeof(string))`, which doesn't match the registered keyed service. Filtering silently misses.

This only affects **non-string keys** under **class interception**. String keys round-trip through `object` losslessly, and interface interception does not rewrite the constructor, so both are unaffected.

Filed upstream with a minimal, Autofac-free repro: **castleproject/Core#748** (not fixed in the latest released Castle.Core 5.2.1, nor on their unreleased 6.0.0 branch).

## This PR

Rather than ship a fragile re-injection workaround that duplicates core's filtering logic, this adds a documenting test fixture (`ClassInterceptorsWithAttributeFilteringFixture`) that:

- **Pins the current (incorrect) behavior** for an enum key with class interception. If Castle fixes the upstream bug, this test will start failing — signaling that the limitation (and its docs/comments) can be removed.
- Establishes the **baseline** (enum filtering works without interception).
- Demonstrates the two supported **workarounds**: use a string key, or use `EnableInterfaceInterceptors` instead of `EnableClassInterceptors`.

The class-level XML doc captures the root cause and links both #56 and castleproject/Core#748 so the rationale travels with the code.

## Validation

- 46/46 tests pass on net8.0 and net10.0.
- Clean Release build (warnings-as-errors + analyzers) and `dotnet format` clean.

No production code changes — tests and documentation only. Suggest leaving #56 open to track the upstream fix.