### PR TITLE
Preserve optional constructor argument defaults on class proxies

### DIFF
--- a/bench/Autofac.Extras.DynamicProxy.Benchmarks/Autofac.Extras.DynamicProxy.Benchmarks.csproj
+++ b/bench/Autofac.Extras.DynamicProxy.Benchmarks/Autofac.Extras.DynamicProxy.Benchmarks.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.32.0.713">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/bench/Autofac.Extras.DynamicProxy.Benchmarks/ClassInterceptionBenchmark.cs
+++ b/bench/Autofac.Extras.DynamicProxy.Benchmarks/ClassInterceptionBenchmark.cs
@@ -21,6 +21,9 @@ public class ClassInterceptionBenchmark
         builder.RegisterType<ClassWithoutInterceptAttribute>()
             .EnableClassInterceptors()
             .InterceptedBy(typeof(StringMethodInterceptor));
+        builder.RegisterType<ClassWithOptionalParameter>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(StringMethodInterceptor));
         builder.RegisterType<StringMethodInterceptor>();
         _container = builder.Build();
     }
@@ -36,6 +39,13 @@ public class ClassInterceptionBenchmark
     public string WiredUsingInterceptedBy()
     {
         var instance = _container.Resolve<ClassWithoutInterceptAttribute>();
+        return instance.Test();
+    }
+
+    [Benchmark]
+    public string WithOptionalConstructorParameter()
+    {
+        var instance = _container.Resolve<ClassWithOptionalParameter>();
         return instance.Test();
     }
 }

--- a/bench/Autofac.Extras.DynamicProxy.Benchmarks/Scenario/ClassWithOptionalParameter.cs
+++ b/bench/Autofac.Extras.DynamicProxy.Benchmarks/Scenario/ClassWithOptionalParameter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Extras.DynamicProxy.Benchmarks.Scenario;
+
+public class ClassWithOptionalParameter : ITest
+{
+    private readonly int _count;
+
+    public ClassWithOptionalParameter(int count = 42)
+    {
+        _count = count;
+    }
+
+    public virtual string Test()
+    {
+        return _count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+}

--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>8.0.1</Version>
+    <Version>8.1.0</Version>
     <SolutionName>Autofac.Extras.DynamicProxy</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extras.DynamicProxy/Autofac.Extras.DynamicProxy.csproj
+++ b/src/Autofac.Extras.DynamicProxy/Autofac.Extras.DynamicProxy.csproj
@@ -54,12 +54,12 @@
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.1" />
+    <PackageReference Include="Autofac" Version="9.3.2" />
     <PackageReference Include="Castle.Core" Version="5.2.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.32.0.713">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Autofac.Extras.DynamicProxy/Polyfills/NotNullWhenAttribute.cs
+++ b/src/Autofac.Extras.DynamicProxy/Polyfills/NotNullWhenAttribute.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Polyfill for <see cref="NotNullWhenAttribute"/> which is not available in netstandard2.0.
+/// Specifies that when a method returns <see cref="ReturnValue"/>,
+/// the parameter will not be null even if the corresponding type allows it.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotNullWhenAttribute"/> class.
+    /// </summary>
+    /// <param name="returnValue">
+    /// The return value condition. If the method returns this value, the associated parameter will not be null.
+    /// </param>
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the return value should be true or false for the parameter to be non-null.
+    /// </summary>
+    public bool ReturnValue
+    {
+        get;
+    }
+}
+
+#endif

--- a/src/Autofac.Extras.DynamicProxy/Polyfills/NotNullWhenAttribute.cs
+++ b/src/Autofac.Extras.DynamicProxy/Polyfills/NotNullWhenAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #if NETSTANDARD2_0

--- a/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
+++ b/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;

--- a/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
+++ b/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
@@ -31,6 +31,8 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
 
     private readonly IEnumerable<Parameter> _configuredParameters;
 
+    private readonly int _proxyArgumentCount;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ProxiedDefaultValueParameter"/> class.
     /// </summary>
@@ -41,10 +43,16 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
     /// The parameters configured on the registration. These take precedence over
     /// default values, so they're checked before one is supplied.
     /// </param>
-    public ProxiedDefaultValueParameter(Type proxiedType, IEnumerable<Parameter> configuredParameters)
+    /// <param name="proxyArgumentCount">
+    /// The number of leading arguments the generated constructors take for the proxy
+    /// itself - the mixins, the interceptor array, and the selector. The parameters
+    /// mirrored from the proxied type start after these.
+    /// </param>
+    public ProxiedDefaultValueParameter(Type proxiedType, IEnumerable<Parameter> configuredParameters, int proxyArgumentCount)
     {
         _proxiedType = proxiedType;
         _configuredParameters = configuredParameters;
+        _proxyArgumentCount = proxyArgumentCount;
     }
 
     /// <inheritdoc/>
@@ -87,7 +95,28 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
 
         var proxied = FindProxiedParameter(pi);
 
-        if (proxied is null || !proxied.HasDefaultValue)
+        if (proxied is null)
+        {
+            return false;
+        }
+
+        bool hasDefaultValue;
+
+        try
+        {
+            hasDefaultValue = proxied.HasDefaultValue;
+        }
+        catch (FormatException) when (proxied.ParameterType == typeof(DateTime))
+        {
+            // Workaround for https://github.com/dotnet/corefx/issues/12338, mirroring
+            // the handling in Autofac's DefaultValueParameter. Reading the default
+            // value of a DateTime parameter can throw, in which case the parameter is
+            // known to have one.
+            valueProvider = () => default(DateTime);
+            return true;
+        }
+
+        if (!hasDefaultValue)
         {
             return false;
         }
@@ -114,20 +143,71 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
     /// The matching parameter on the proxied type, or <see langword="null" /> if
     /// there isn't one.
     /// </returns>
+    /// <remarks>
+    /// <para>
+    /// A generated constructor takes the arguments the proxy itself needs and then
+    /// mirrors, in order, the parameters of the one constructor it chains to. The
+    /// whole mirrored signature has to be matched to find that constructor:
+    /// overloads can share a parameter name and type while declaring different
+    /// default values, so matching a single parameter across all of them picks up
+    /// the wrong default.
+    /// </para>
+    /// </remarks>
     private ParameterInfo? FindProxiedParameter(ParameterInfo pi)
     {
+        var mirroredPosition = pi.Position - _proxyArgumentCount;
+
+        if (mirroredPosition < 0)
+        {
+            // An argument belonging to the proxy rather than to the proxied type.
+            return null;
+        }
+
+        var mirrored = ((ConstructorInfo)pi.Member).GetParameters();
+
+        // Non-public constructors are included because a protected constructor is
+        // mirrored by a public one on the proxy, which the container can then select.
         foreach (var constructor in _proxiedType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
         {
-            foreach (var parameter in constructor.GetParameters())
+            var candidates = constructor.GetParameters();
+
+            if (candidates.Length != mirrored.Length - _proxyArgumentCount)
             {
-                if (string.Equals(parameter.Name, pi.Name, StringComparison.Ordinal) &&
-                    parameter.ParameterType == pi.ParameterType)
-                {
-                    return parameter;
-                }
+                continue;
+            }
+
+            if (IsMirroredBy(candidates, mirrored))
+            {
+                return candidates[mirroredPosition];
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Determines whether the parameters of a constructor on the proxied type are the
+    /// ones a generated constructor mirrors.
+    /// </summary>
+    /// <param name="candidates">The parameters of a constructor on the proxied type.</param>
+    /// <param name="mirrored">The parameters of the generated proxy constructor.</param>
+    /// <returns>
+    /// <see langword="true" /> if the generated constructor mirrors
+    /// <paramref name="candidates" />; otherwise, <see langword="false" />.
+    /// </returns>
+    private bool IsMirroredBy(ParameterInfo[] candidates, ParameterInfo[] mirrored)
+    {
+        for (var i = 0; i < candidates.Length; i++)
+        {
+            var proxyParameter = mirrored[i + _proxyArgumentCount];
+
+            if (!string.Equals(candidates[i].Name, proxyParameter.Name, StringComparison.Ordinal) ||
+                candidates[i].ParameterType != proxyParameter.ParameterType)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
+++ b/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
@@ -22,6 +22,10 @@ namespace Autofac.Extras.DynamicProxy;
 /// proxy's behalf.
 /// </para>
 /// <para>
+/// The values are read once, when this parameter is created, so resolving costs
+/// a dictionary lookup rather than a walk over the constructors.
+/// </para>
+/// <para>
 /// This is a last resort. Values passed to the resolve operation, values
 /// configured on the registration, and services available from the container
 /// all take precedence, which keeps binding behavior the same as it would be
@@ -30,16 +34,18 @@ namespace Autofac.Extras.DynamicProxy;
 /// </remarks>
 internal sealed class ProxiedDefaultValueParameter : Parameter
 {
-    private readonly Type _proxiedType;
-
     private readonly IEnumerable<Parameter> _configuredParameters;
 
-    private readonly int _proxyArgumentCount;
+    private readonly Dictionary<ParameterInfo, Func<object?>> _defaultValues;
 
     /// <summary>
     /// Initializes a new instance of the
     /// <see cref="ProxiedDefaultValueParameter"/> class.
     /// </summary>
+    /// <param name="proxyType">
+    /// The generated proxy type, whose constructor parameters are the ones being
+    /// supplied.
+    /// </param>
     /// <param name="proxiedType">
     /// The type that was proxied; the source of the default values.
     /// </param>
@@ -52,31 +58,18 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
     /// proxy itself - the mixins, the interceptor array, and the selector. The
     /// parameters mirrored from the proxied type start after these.
     /// </param>
-    public ProxiedDefaultValueParameter(Type proxiedType, IEnumerable<Parameter> configuredParameters, int proxyArgumentCount)
+    public ProxiedDefaultValueParameter(Type proxyType, Type proxiedType, IEnumerable<Parameter> configuredParameters, int proxyArgumentCount)
     {
-        _proxiedType = proxiedType;
         _configuredParameters = configuredParameters;
-        _proxyArgumentCount = proxyArgumentCount;
+        _defaultValues = FindDefaultValues(proxyType, proxiedType, proxyArgumentCount);
     }
 
     /// <inheritdoc/>
     public override bool CanSupplyValue(ParameterInfo pi, IComponentContext context, [NotNullWhen(returnValue: true)] out Func<object?>? valueProvider)
     {
-        if (pi == null)
-        {
-            throw new ArgumentNullException(nameof(pi));
-        }
-
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-
         valueProvider = null;
 
-        // Only generated proxy constructors are missing default values.
-        // Anything else already binds correctly on its own.
-        if (pi.Member is not ConstructorInfo || !_proxiedType.IsAssignableFrom(pi.Member.DeclaringType))
+        if (!_defaultValues.TryGetValue(pi, out var defaultValueProvider))
         {
             return false;
         }
@@ -97,127 +90,150 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
             }
         }
 
-        var proxied = FindProxiedParameter(pi);
-
-        if (proxied is null)
-        {
-            return false;
-        }
-
-        bool hasDefaultValue;
-
-        try
-        {
-            hasDefaultValue = proxied.HasDefaultValue;
-        }
-        catch (FormatException) when (proxied.ParameterType == typeof(DateTime))
-        {
-            // Workaround for https://github.com/dotnet/corefx/issues/12338,
-            // mirroring the handling in Autofac's DefaultValueParameter.
-            // Reading the default value of a DateTime parameter can throw, in
-            // which case the parameter is known to have one.
-            valueProvider = () => default(DateTime);
-            return true;
-        }
-
-        if (!hasDefaultValue)
-        {
-            return false;
-        }
-
-        var defaultValue = proxied.DefaultValue;
-
-        // Workaround for https://github.com/dotnet/corefx/issues/11797,
-        // mirroring the handling in Autofac's DefaultValueParameter.
-        if (defaultValue is null && pi.ParameterType.IsValueType)
-        {
-            defaultValue = Activator.CreateInstance(pi.ParameterType);
-        }
-
-        valueProvider = () => defaultValue;
+        valueProvider = defaultValueProvider;
         return true;
     }
 
     /// <summary>
-    /// Locates the parameter on the proxied type that corresponds to a
-    /// parameter on the generated proxy constructor.
+    /// Reads the default values the generated constructors dropped, keyed by the
+    /// proxy constructor parameter each one belongs to.
     /// </summary>
-    /// <param name="pi">
-    /// The proxy constructor parameter.
+    /// <param name="proxyType">The generated proxy type.</param>
+    /// <param name="proxiedType">The type that was proxied.</param>
+    /// <param name="proxyArgumentCount">
+    /// The number of leading arguments the generated constructors take for the
+    /// proxy itself.
     /// </param>
     /// <returns>
-    /// The matching parameter on the proxied type, or <see langword="null" />
-    /// if there isn't one.
+    /// The default value providers for the parameters that have one.
     /// </returns>
     /// <remarks>
     /// <para>
-    /// A generated constructor takes the arguments the proxy itself needs and
-    /// then mirrors, in order, the parameters of the one constructor it chains
-    /// to. The whole mirrored signature has to be matched to find that
-    /// constructor: overloads can share a parameter name and type while
-    /// declaring different default values, so matching a single parameter
+    /// A generated constructor mirrors, in order, the parameters of the one
+    /// constructor it chains to. The whole mirrored signature has to be matched
+    /// to find that constructor: overloads can share a parameter name and type
+    /// while declaring different default values, so matching a single parameter
     /// across all of them picks up the wrong default.
     /// </para>
     /// </remarks>
-    private ParameterInfo? FindProxiedParameter(ParameterInfo pi)
+    private static Dictionary<ParameterInfo, Func<object?>> FindDefaultValues(Type proxyType, Type proxiedType, int proxyArgumentCount)
     {
-        var mirroredPosition = pi.Position - _proxyArgumentCount;
-
-        if (mirroredPosition < 0)
-        {
-            // An argument belonging to the proxy rather than to the proxied
-            // type.
-            return null;
-        }
-
-        var mirrored = ((ConstructorInfo)pi.Member).GetParameters();
+        var defaultValues = new Dictionary<ParameterInfo, Func<object?>>();
 
         // Non-public constructors are included because a protected constructor
-        // is mirrored by a public one on the proxy, which the container can
-        // then select.
-        foreach (var constructor in _proxiedType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        // is mirrored by a public one on the proxy, which the container can then
+        // select.
+        var proxiedConstructors = proxiedType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        foreach (var proxyConstructor in proxyType.GetConstructors())
         {
-            var candidates = constructor.GetParameters();
+            var mirrored = proxyConstructor.GetParameters();
 
-            if (candidates.Length != mirrored.Length - _proxyArgumentCount)
+            foreach (var proxiedConstructor in proxiedConstructors)
             {
-                continue;
-            }
+                var proxied = proxiedConstructor.GetParameters();
 
-            if (IsMirroredBy(candidates, mirrored))
-            {
-                return candidates[mirroredPosition];
+                if (proxied.Length != mirrored.Length - proxyArgumentCount ||
+                    !IsMirroredBy(proxied, mirrored, proxyArgumentCount))
+                {
+                    continue;
+                }
+
+                AddDefaultValues(defaultValues, proxied, mirrored, proxyArgumentCount);
+                break;
             }
         }
 
-        return null;
+        return defaultValues;
     }
 
     /// <summary>
     /// Determines whether the parameters of a constructor on the proxied type
     /// are the ones a generated constructor mirrors.
     /// </summary>
-    /// <param name="candidates">
+    /// <param name="proxied">
     /// The parameters of a constructor on the proxied type.
     /// </param>
     /// <param name="mirrored">
     /// The parameters of the generated proxy constructor.
     /// </param>
+    /// <param name="proxyArgumentCount">
+    /// The number of leading arguments the generated constructor takes for the
+    /// proxy itself.
+    /// </param>
     /// <returns>
     /// <see langword="true" /> if the generated constructor mirrors
-    /// <paramref name="candidates" />; otherwise, <see langword="false" />.
+    /// <paramref name="proxied" />; otherwise, <see langword="false" />.
     /// </returns>
-    private bool IsMirroredBy(ParameterInfo[] candidates, ParameterInfo[] mirrored)
+    private static bool IsMirroredBy(ParameterInfo[] proxied, ParameterInfo[] mirrored, int proxyArgumentCount)
     {
-        for (var i = 0; i < candidates.Length; i++)
+        for (var i = 0; i < proxied.Length; i++)
         {
-            var proxyParameter = mirrored[i + _proxyArgumentCount];
+            var proxyParameter = mirrored[i + proxyArgumentCount];
 
-            if (!string.Equals(candidates[i].Name, proxyParameter.Name, StringComparison.Ordinal) ||
-                candidates[i].ParameterType != proxyParameter.ParameterType)
+            if (!string.Equals(proxied[i].Name, proxyParameter.Name, StringComparison.Ordinal) ||
+                proxied[i].ParameterType != proxyParameter.ParameterType)
             {
                 return false;
             }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Records the default values declared on a constructor of the proxied type
+    /// against the parameters of the generated constructor mirroring it.
+    /// </summary>
+    /// <param name="defaultValues">The set of default values being built.</param>
+    /// <param name="proxied">
+    /// The parameters of the constructor on the proxied type.
+    /// </param>
+    /// <param name="mirrored">
+    /// The parameters of the generated proxy constructor.
+    /// </param>
+    /// <param name="proxyArgumentCount">
+    /// The number of leading arguments the generated constructor takes for the
+    /// proxy itself.
+    /// </param>
+    private static void AddDefaultValues(Dictionary<ParameterInfo, Func<object?>> defaultValues, ParameterInfo[] proxied, ParameterInfo[] mirrored, int proxyArgumentCount)
+    {
+        for (var i = 0; i < proxied.Length; i++)
+        {
+            if (TryGetDefaultValue(proxied[i], out var defaultValue))
+            {
+                defaultValues.Add(mirrored[i + proxyArgumentCount], () => defaultValue);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the default value declared on a parameter of the proxied type.
+    /// </summary>
+    /// <param name="proxied">The parameter on the proxied type.</param>
+    /// <param name="defaultValue">
+    /// The default value, if the parameter declares one.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the parameter declares a default value;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    private static bool TryGetDefaultValue(ParameterInfo proxied, out object? defaultValue)
+    {
+        defaultValue = null;
+
+        if (!proxied.HasDefaultValue)
+        {
+            return false;
+        }
+
+        defaultValue = proxied.DefaultValue;
+
+        // Workaround for https://github.com/dotnet/corefx/issues/11797,
+        // mirroring the handling in Autofac's DefaultValueParameter.
+        if (defaultValue is null && proxied.ParameterType.IsValueType)
+        {
+            defaultValue = Activator.CreateInstance(proxied.ParameterType);
         }
 
         return true;

--- a/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
+++ b/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using Autofac.Core;
+
+namespace Autofac.Extras.DynamicProxy;
+
+/// <summary>
+/// Supplies optional constructor argument values that are lost when a class proxy
+/// is generated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Class interception replaces the registered implementation type with a generated
+/// proxy subclass. The generated constructors mirror the parameters of the type
+/// being proxied, but they don't carry the default values of those parameters, so
+/// <see cref="Autofac.Core.Activators.Reflection.DefaultValueParameter"/> can't see
+/// them and optional arguments fail to bind. This parameter reads the default values
+/// from the type that was proxied and supplies them on the proxy's behalf.
+/// </para>
+/// <para>
+/// This is a last resort. Values passed to the resolve operation, values configured
+/// on the registration, and services available from the container all take
+/// precedence, which keeps binding behavior the same as it would be without a proxy.
+/// </para>
+/// </remarks>
+internal sealed class ProxiedDefaultValueParameter : Parameter
+{
+    private readonly Type _proxiedType;
+
+    private readonly IEnumerable<Parameter> _configuredParameters;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProxiedDefaultValueParameter"/> class.
+    /// </summary>
+    /// <param name="proxiedType">
+    /// The type that was proxied; the source of the default values.
+    /// </param>
+    /// <param name="configuredParameters">
+    /// The parameters configured on the registration. These take precedence over
+    /// default values, so they're checked before one is supplied.
+    /// </param>
+    public ProxiedDefaultValueParameter(Type proxiedType, IEnumerable<Parameter> configuredParameters)
+    {
+        _proxiedType = proxiedType;
+        _configuredParameters = configuredParameters;
+    }
+
+    /// <inheritdoc/>
+    public override bool CanSupplyValue(ParameterInfo pi, IComponentContext context, [NotNullWhen(returnValue: true)] out Func<object?>? valueProvider)
+    {
+        if (pi == null)
+        {
+            throw new ArgumentNullException(nameof(pi));
+        }
+
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        valueProvider = null;
+
+        // Only generated proxy constructors are missing default values. Anything
+        // else already binds correctly on its own.
+        if (pi.Member is not ConstructorInfo || !_proxiedType.IsAssignableFrom(pi.Member.DeclaringType))
+        {
+            return false;
+        }
+
+        // Defer to the container when the service is genuinely available; autowiring
+        // wins over a default value on an unproxied type too.
+        if (context.ComponentRegistry.TryGetServiceRegistration(new TypedService(pi.ParameterType), out _))
+        {
+            return false;
+        }
+
+        // Defer to anything explicitly configured on the registration.
+        foreach (var configured in _configuredParameters)
+        {
+            if (configured.CanSupplyValue(pi, context, out _))
+            {
+                return false;
+            }
+        }
+
+        var proxied = FindProxiedParameter(pi);
+
+        if (proxied is null || !proxied.HasDefaultValue)
+        {
+            return false;
+        }
+
+        var defaultValue = proxied.DefaultValue;
+
+        // Workaround for https://github.com/dotnet/corefx/issues/11797, mirroring
+        // the handling in Autofac's DefaultValueParameter.
+        if (defaultValue is null && pi.ParameterType.IsValueType)
+        {
+            defaultValue = Activator.CreateInstance(pi.ParameterType);
+        }
+
+        valueProvider = () => defaultValue;
+        return true;
+    }
+
+    /// <summary>
+    /// Locates the parameter on the proxied type that corresponds to a parameter on
+    /// the generated proxy constructor.
+    /// </summary>
+    /// <param name="pi">The proxy constructor parameter.</param>
+    /// <returns>
+    /// The matching parameter on the proxied type, or <see langword="null" /> if
+    /// there isn't one.
+    /// </returns>
+    private ParameterInfo? FindProxiedParameter(ParameterInfo pi)
+    {
+        foreach (var constructor in _proxiedType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        {
+            foreach (var parameter in constructor.GetParameters())
+            {
+                if (string.Equals(parameter.Name, pi.Name, StringComparison.Ordinal) &&
+                    parameter.ParameterType == pi.ParameterType)
+                {
+                    return parameter;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
+++ b/src/Autofac.Extras.DynamicProxy/ProxiedDefaultValueParameter.cs
@@ -7,22 +7,25 @@ using Autofac.Core;
 namespace Autofac.Extras.DynamicProxy;
 
 /// <summary>
-/// Supplies optional constructor argument values that are lost when a class proxy
-/// is generated.
+/// Supplies optional constructor argument values that are lost when a class
+/// proxy is generated.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Class interception replaces the registered implementation type with a generated
-/// proxy subclass. The generated constructors mirror the parameters of the type
-/// being proxied, but they don't carry the default values of those parameters, so
-/// <see cref="Autofac.Core.Activators.Reflection.DefaultValueParameter"/> can't see
-/// them and optional arguments fail to bind. This parameter reads the default values
-/// from the type that was proxied and supplies them on the proxy's behalf.
+/// Class interception replaces the registered implementation type with a
+/// generated proxy subclass. The generated constructors mirror the parameters
+/// of the type being proxied, but they don't carry the default values of those
+/// parameters, so
+/// <see cref="Autofac.Core.Activators.Reflection.DefaultValueParameter"/> can't
+/// see them and optional arguments fail to bind. This parameter reads the
+/// default values from the type that was proxied and supplies them on the
+/// proxy's behalf.
 /// </para>
 /// <para>
-/// This is a last resort. Values passed to the resolve operation, values configured
-/// on the registration, and services available from the container all take
-/// precedence, which keeps binding behavior the same as it would be without a proxy.
+/// This is a last resort. Values passed to the resolve operation, values
+/// configured on the registration, and services available from the container
+/// all take precedence, which keeps binding behavior the same as it would be
+/// without a proxy.
 /// </para>
 /// </remarks>
 internal sealed class ProxiedDefaultValueParameter : Parameter
@@ -34,19 +37,20 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
     private readonly int _proxyArgumentCount;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProxiedDefaultValueParameter"/> class.
+    /// Initializes a new instance of the
+    /// <see cref="ProxiedDefaultValueParameter"/> class.
     /// </summary>
     /// <param name="proxiedType">
     /// The type that was proxied; the source of the default values.
     /// </param>
     /// <param name="configuredParameters">
-    /// The parameters configured on the registration. These take precedence over
-    /// default values, so they're checked before one is supplied.
+    /// The parameters configured on the registration. These take precedence
+    /// over default values, so they're checked before one is supplied.
     /// </param>
     /// <param name="proxyArgumentCount">
-    /// The number of leading arguments the generated constructors take for the proxy
-    /// itself - the mixins, the interceptor array, and the selector. The parameters
-    /// mirrored from the proxied type start after these.
+    /// The number of leading arguments the generated constructors take for the
+    /// proxy itself - the mixins, the interceptor array, and the selector. The
+    /// parameters mirrored from the proxied type start after these.
     /// </param>
     public ProxiedDefaultValueParameter(Type proxiedType, IEnumerable<Parameter> configuredParameters, int proxyArgumentCount)
     {
@@ -70,15 +74,15 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
 
         valueProvider = null;
 
-        // Only generated proxy constructors are missing default values. Anything
-        // else already binds correctly on its own.
+        // Only generated proxy constructors are missing default values.
+        // Anything else already binds correctly on its own.
         if (pi.Member is not ConstructorInfo || !_proxiedType.IsAssignableFrom(pi.Member.DeclaringType))
         {
             return false;
         }
 
-        // Defer to the container when the service is genuinely available; autowiring
-        // wins over a default value on an unproxied type too.
+        // Defer to the container when the service is genuinely available;
+        // autowiring wins over a default value on an unproxied type too.
         if (context.ComponentRegistry.TryGetServiceRegistration(new TypedService(pi.ParameterType), out _))
         {
             return false;
@@ -108,10 +112,10 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
         }
         catch (FormatException) when (proxied.ParameterType == typeof(DateTime))
         {
-            // Workaround for https://github.com/dotnet/corefx/issues/12338, mirroring
-            // the handling in Autofac's DefaultValueParameter. Reading the default
-            // value of a DateTime parameter can throw, in which case the parameter is
-            // known to have one.
+            // Workaround for https://github.com/dotnet/corefx/issues/12338,
+            // mirroring the handling in Autofac's DefaultValueParameter.
+            // Reading the default value of a DateTime parameter can throw, in
+            // which case the parameter is known to have one.
             valueProvider = () => default(DateTime);
             return true;
         }
@@ -123,8 +127,8 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
 
         var defaultValue = proxied.DefaultValue;
 
-        // Workaround for https://github.com/dotnet/corefx/issues/11797, mirroring
-        // the handling in Autofac's DefaultValueParameter.
+        // Workaround for https://github.com/dotnet/corefx/issues/11797,
+        // mirroring the handling in Autofac's DefaultValueParameter.
         if (defaultValue is null && pi.ParameterType.IsValueType)
         {
             defaultValue = Activator.CreateInstance(pi.ParameterType);
@@ -135,22 +139,24 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
     }
 
     /// <summary>
-    /// Locates the parameter on the proxied type that corresponds to a parameter on
-    /// the generated proxy constructor.
+    /// Locates the parameter on the proxied type that corresponds to a
+    /// parameter on the generated proxy constructor.
     /// </summary>
-    /// <param name="pi">The proxy constructor parameter.</param>
+    /// <param name="pi">
+    /// The proxy constructor parameter.
+    /// </param>
     /// <returns>
-    /// The matching parameter on the proxied type, or <see langword="null" /> if
-    /// there isn't one.
+    /// The matching parameter on the proxied type, or <see langword="null" />
+    /// if there isn't one.
     /// </returns>
     /// <remarks>
     /// <para>
-    /// A generated constructor takes the arguments the proxy itself needs and then
-    /// mirrors, in order, the parameters of the one constructor it chains to. The
-    /// whole mirrored signature has to be matched to find that constructor:
-    /// overloads can share a parameter name and type while declaring different
-    /// default values, so matching a single parameter across all of them picks up
-    /// the wrong default.
+    /// A generated constructor takes the arguments the proxy itself needs and
+    /// then mirrors, in order, the parameters of the one constructor it chains
+    /// to. The whole mirrored signature has to be matched to find that
+    /// constructor: overloads can share a parameter name and type while
+    /// declaring different default values, so matching a single parameter
+    /// across all of them picks up the wrong default.
     /// </para>
     /// </remarks>
     private ParameterInfo? FindProxiedParameter(ParameterInfo pi)
@@ -159,14 +165,16 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
 
         if (mirroredPosition < 0)
         {
-            // An argument belonging to the proxy rather than to the proxied type.
+            // An argument belonging to the proxy rather than to the proxied
+            // type.
             return null;
         }
 
         var mirrored = ((ConstructorInfo)pi.Member).GetParameters();
 
-        // Non-public constructors are included because a protected constructor is
-        // mirrored by a public one on the proxy, which the container can then select.
+        // Non-public constructors are included because a protected constructor
+        // is mirrored by a public one on the proxy, which the container can
+        // then select.
         foreach (var constructor in _proxiedType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
         {
             var candidates = constructor.GetParameters();
@@ -186,11 +194,15 @@ internal sealed class ProxiedDefaultValueParameter : Parameter
     }
 
     /// <summary>
-    /// Determines whether the parameters of a constructor on the proxied type are the
-    /// ones a generated constructor mirrors.
+    /// Determines whether the parameters of a constructor on the proxied type
+    /// are the ones a generated constructor mirrors.
     /// </summary>
-    /// <param name="candidates">The parameters of a constructor on the proxied type.</param>
-    /// <param name="mirrored">The parameters of the generated proxy constructor.</param>
+    /// <param name="candidates">
+    /// The parameters of a constructor on the proxied type.
+    /// </param>
+    /// <param name="mirrored">
+    /// The parameters of the generated proxy constructor.
+    /// </param>
     /// <returns>
     /// <see langword="true" /> if the generated constructor mirrors
     /// <paramref name="candidates" />; otherwise, <see langword="false" />.

--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -311,9 +311,14 @@ public static class RegistrationExtensions
             return registration;
         }
 
+        // The generated proxy constructors don't carry the default values of the
+        // parameters they mirror, so keep hold of the type being proxied to read
+        // them back when binding.
+        var proxiedType = registration.ActivatorData.ImplementationType;
+
         registration.ActivatorData.ImplementationType =
             _proxyGenerator.ProxyBuilder.CreateClassProxyType(
-                registration.ActivatorData.ImplementationType,
+                proxiedType,
                 additionalInterfaces ?? Type.EmptyTypes,
                 options);
 
@@ -343,7 +348,10 @@ public static class RegistrationExtensions
                 proxyParameters.Add(new PositionalParameter(index, options.Selector));
             }
 
-            e.Parameters = proxyParameters.Concat(e.Parameters).ToArray();
+            e.Parameters = proxyParameters
+                .Concat(e.Parameters)
+                .Concat(new Parameter[] { new ProxiedDefaultValueParameter(proxiedType, registration.ActivatorData.ConfiguredParameters) })
+                .ToArray();
         });
 
         return registration;

--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -350,7 +350,7 @@ public static class RegistrationExtensions
 
             e.Parameters = proxyParameters
                 .Concat(e.Parameters)
-                .Concat(new Parameter[] { new ProxiedDefaultValueParameter(proxiedType, registration.ActivatorData.ConfiguredParameters) })
+                .Concat(new Parameter[] { new ProxiedDefaultValueParameter(proxiedType, registration.ActivatorData.ConfiguredParameters, proxyParameters.Count) })
                 .ToArray();
         });
 

--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -312,9 +312,6 @@ public static class RegistrationExtensions
             return registration;
         }
 
-        // The generated proxy constructors don't carry the default values of
-        // the parameters they mirror, so keep hold of the type being proxied to
-        // read them back when binding.
         var proxiedType = registration.ActivatorData.ImplementationType;
 
         registration.ActivatorData.ImplementationType =
@@ -325,6 +322,13 @@ public static class RegistrationExtensions
 
         var interceptorServices = GetInterceptorServicesFromAttributes(registration.ActivatorData.ImplementationType);
         AddInterceptorServicesToMetadata(registration, interceptorServices, AttributeInterceptorsPropertyName);
+
+        // The generated proxy constructors don't carry the default values of the
+        // parameters they mirror. Those are read from the type being proxied,
+        // once, the first time something is resolved - the number of arguments
+        // the proxy takes for itself isn't known until the parameters supplying
+        // them have been built.
+        ProxiedDefaultValueParameter? proxiedDefaultValues = null;
 
         registration.OnPreparing(e =>
         {
@@ -349,9 +353,15 @@ public static class RegistrationExtensions
                 proxyParameters.Add(new PositionalParameter(index, options.Selector));
             }
 
+            proxiedDefaultValues ??= new ProxiedDefaultValueParameter(
+                registration.ActivatorData.ImplementationType,
+                proxiedType,
+                registration.ActivatorData.ConfiguredParameters,
+                proxyParameters.Count);
+
             e.Parameters = proxyParameters
                 .Concat(e.Parameters)
-                .Concat(new Parameter[] { new ProxiedDefaultValueParameter(proxiedType, registration.ActivatorData.ConfiguredParameters, proxyParameters.Count) })
+                .Append(proxiedDefaultValues)
                 .ToArray();
         });
 

--- a/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
+++ b/src/Autofac.Extras.DynamicProxy/RegistrationExtensions.cs
@@ -303,17 +303,18 @@ public static class RegistrationExtensions
             throw new ArgumentNullException(nameof(registration));
         }
 
-        // Class interception rewrites the implementation type to a proxy subclass
-        // at registration time, so the decision to intercept is made here, per type.
-        // When the predicate rejects the type the registration is left untouched.
+        // Class interception rewrites the implementation type to a proxy
+        // subclass at registration time, so the decision to intercept is made
+        // here, per type. When the predicate rejects the type the registration
+        // is left untouched.
         if (shouldIntercept != null && !shouldIntercept(registration.ActivatorData.ImplementationType))
         {
             return registration;
         }
 
-        // The generated proxy constructors don't carry the default values of the
-        // parameters they mirror, so keep hold of the type being proxied to read
-        // them back when binding.
+        // The generated proxy constructors don't carry the default values of
+        // the parameters they mirror, so keep hold of the type being proxied to
+        // read them back when binding.
         var proxiedType = registration.ActivatorData.ImplementationType;
 
         registration.ActivatorData.ImplementationType =

--- a/test/Autofac.Extras.DynamicProxy.Test.SatelliteAssembly/Autofac.Extras.DynamicProxy.Test.SatelliteAssembly.csproj
+++ b/test/Autofac.Extras.DynamicProxy.Test.SatelliteAssembly/Autofac.Extras.DynamicProxy.Test.SatelliteAssembly.csproj
@@ -18,7 +18,7 @@
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.32.0.713">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Extras.DynamicProxy.Test/Autofac.Extras.DynamicProxy.Test.csproj
+++ b/test/Autofac.Extras.DynamicProxy.Test/Autofac.Extras.DynamicProxy.Test.csproj
@@ -30,8 +30,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.32.0.713">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core;

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
@@ -12,9 +12,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
     public void OptionalReferenceParameterUsesDefaultWhenNotRegistered()
     {
         var container = BuildContainer<HasOptionalDependency>();
-
         var instance = container.Resolve<HasOptionalDependency>();
-
         Assert.Null(instance.Dependency);
     }
 
@@ -22,9 +20,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
     public void OptionalValueParameterUsesDefaultWhenNotRegistered()
     {
         var container = BuildContainer<HasOptionalValue>();
-
         var instance = container.Resolve<HasOptionalValue>();
-
         Assert.Equal(42, instance.Count);
     }
 
@@ -37,9 +33,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
             .InterceptedBy(typeof(AddOneInterceptor));
         builder.RegisterType<AddOneInterceptor>();
         var container = builder.Build();
-
         var instance = container.Resolve<HasOptionalValue>();
-
         Assert.Equal(43, instance.GetCountByMethod());
     }
 
@@ -53,9 +47,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
         builder.RegisterType<DoNothingInterceptor>();
         builder.RegisterType<Dependency>().As<IDependency>();
         var container = builder.Build();
-
         var instance = container.Resolve<HasOptionalDependency>();
-
         Assert.IsType<Dependency>(instance.Dependency);
     }
 
@@ -70,9 +62,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
             .WithParameter(TypedParameter.From<IDependency>(expected));
         builder.RegisterType<DoNothingInterceptor>();
         var container = builder.Build();
-
         var instance = container.Resolve<HasOptionalDependency>();
-
         Assert.Same(expected, instance.Dependency);
     }
 
@@ -81,9 +71,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
     {
         var container = BuildContainer<HasOptionalDependency>();
         var expected = new Dependency();
-
         var instance = container.Resolve<HasOptionalDependency>(TypedParameter.From<IDependency>(expected));
-
         Assert.Same(expected, instance.Dependency);
     }
 
@@ -91,7 +79,6 @@ public class ClassInterceptorsWithOptionalParametersFixture
     public void RequiredParameterStillThrowsWhenMissing()
     {
         var container = BuildContainer<HasRequiredDependency>();
-
         Assert.Throws<DependencyResolutionException>(() => container.Resolve<HasRequiredDependency>());
     }
 
@@ -105,9 +92,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
             .WithParameter(TypedParameter.From<IDependency>(new Dependency()));
         builder.RegisterType<DoNothingInterceptor>();
         var container = builder.Build();
-
         var instance = container.Resolve<HasOverloadedConstructors>();
-
         Assert.Equal(99, instance.Count);
     }
 
@@ -115,17 +100,15 @@ public class ClassInterceptorsWithOptionalParametersFixture
     public void DefaultComesFromTheShorterConstructorWhenItIsTheOneSelected()
     {
         var container = BuildContainer<HasOverloadedConstructors>();
-
         var instance = container.Resolve<HasOverloadedConstructors>();
-
         Assert.Equal(1, instance.Count);
     }
 
     [Fact]
     public void ProtectedConstructorDefaultIsUsed()
     {
-        // A protected constructor is mirrored by a public one on the proxy, so the
-        // container can select it where it couldn't on the unproxied type.
+        // A protected constructor is mirrored by a public one on the proxy, so
+        // the container can select it where it couldn't on the unproxied type.
         var builder = new ContainerBuilder();
         builder.RegisterType<HasProtectedConstructor>()
             .EnableClassInterceptors()
@@ -133,9 +116,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
             .WithParameter(TypedParameter.From("named"));
         builder.RegisterType<DoNothingInterceptor>();
         var container = builder.Build();
-
         var instance = container.Resolve<HasProtectedConstructor>();
-
         Assert.Equal(7, instance.Count);
     }
 
@@ -143,9 +124,7 @@ public class ClassInterceptorsWithOptionalParametersFixture
     public void OptionalDateTimeParameterUsesDefault()
     {
         var container = BuildContainer<HasOptionalDateTime>();
-
         var instance = container.Resolve<HasOptionalDateTime>();
-
         Assert.Equal(default, instance.When);
     }
 

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Core;
+using Castle.DynamicProxy;
+
+namespace Autofac.Extras.DynamicProxy.Test;
+
+public class ClassInterceptorsWithOptionalParametersFixture
+{
+    [Fact]
+    public void OptionalReferenceParameterUsesDefaultWhenNotRegistered()
+    {
+        var container = BuildContainer<HasOptionalDependency>();
+
+        var instance = container.Resolve<HasOptionalDependency>();
+
+        Assert.Null(instance.Dependency);
+    }
+
+    [Fact]
+    public void OptionalValueParameterUsesDefaultWhenNotRegistered()
+    {
+        var container = BuildContainer<HasOptionalValue>();
+
+        var instance = container.Resolve<HasOptionalValue>();
+
+        Assert.Equal(42, instance.Count);
+    }
+
+    [Fact]
+    public void InterceptionStillAppliesWhenOptionalParameterIsDefaulted()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasOptionalValue>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(AddOneInterceptor));
+        builder.RegisterType<AddOneInterceptor>();
+        var container = builder.Build();
+
+        var instance = container.Resolve<HasOptionalValue>();
+
+        Assert.Equal(43, instance.GetCountByMethod());
+    }
+
+    [Fact]
+    public void RegisteredServiceTakesPrecedenceOverDefault()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasOptionalDependency>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(DoNothingInterceptor));
+        builder.RegisterType<DoNothingInterceptor>();
+        builder.RegisterType<Dependency>().As<IDependency>();
+        var container = builder.Build();
+
+        var instance = container.Resolve<HasOptionalDependency>();
+
+        Assert.IsType<Dependency>(instance.Dependency);
+    }
+
+    [Fact]
+    public void ConfiguredParameterTakesPrecedenceOverDefault()
+    {
+        var expected = new Dependency();
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasOptionalDependency>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(DoNothingInterceptor))
+            .WithParameter(TypedParameter.From<IDependency>(expected));
+        builder.RegisterType<DoNothingInterceptor>();
+        var container = builder.Build();
+
+        var instance = container.Resolve<HasOptionalDependency>();
+
+        Assert.Same(expected, instance.Dependency);
+    }
+
+    [Fact]
+    public void ResolveParameterTakesPrecedenceOverDefault()
+    {
+        var container = BuildContainer<HasOptionalDependency>();
+        var expected = new Dependency();
+
+        var instance = container.Resolve<HasOptionalDependency>(TypedParameter.From<IDependency>(expected));
+
+        Assert.Same(expected, instance.Dependency);
+    }
+
+    [Fact]
+    public void RequiredParameterStillThrowsWhenMissing()
+    {
+        var container = BuildContainer<HasRequiredDependency>();
+
+        Assert.Throws<DependencyResolutionException>(() => container.Resolve<HasRequiredDependency>());
+    }
+
+    private static IContainer BuildContainer<TService>()
+        where TService : class
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<TService>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(DoNothingInterceptor));
+        builder.RegisterType<DoNothingInterceptor>();
+        return builder.Build();
+    }
+
+    public interface IDependency
+    {
+    }
+
+    public class Dependency : IDependency
+    {
+    }
+
+    public class HasOptionalDependency
+    {
+        public HasOptionalDependency(IDependency? dependency = null)
+        {
+            Dependency = dependency;
+        }
+
+        public IDependency? Dependency
+        {
+            get;
+        }
+    }
+
+    public class HasOptionalValue
+    {
+        public HasOptionalValue(int count = 42)
+        {
+            Count = count;
+        }
+
+        public int Count
+        {
+            get;
+        }
+
+        public virtual int GetCountByMethod()
+        {
+            return Count;
+        }
+    }
+
+    public class HasRequiredDependency
+    {
+        public HasRequiredDependency(IDependency dependency)
+        {
+            Dependency = dependency;
+        }
+
+        public IDependency Dependency
+        {
+            get;
+        }
+    }
+
+    private class DoNothingInterceptor : IInterceptor
+    {
+        public void Intercept(IInvocation invocation)
+        {
+            invocation.Proceed();
+        }
+    }
+
+    private class AddOneInterceptor : IInterceptor
+    {
+        public void Intercept(IInvocation invocation)
+        {
+            invocation.Proceed();
+
+            if (invocation.Method.ReturnType == typeof(int))
+            {
+                invocation.ReturnValue = ((int)invocation.ReturnValue!) + 1;
+            }
+        }
+    }
+}

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
@@ -95,6 +95,60 @@ public class ClassInterceptorsWithOptionalParametersFixture
         Assert.Throws<DependencyResolutionException>(() => container.Resolve<HasRequiredDependency>());
     }
 
+    [Fact]
+    public void DefaultComesFromTheSelectedConstructorOverload()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasOverloadedConstructors>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(DoNothingInterceptor))
+            .WithParameter(TypedParameter.From<IDependency>(new Dependency()));
+        builder.RegisterType<DoNothingInterceptor>();
+        var container = builder.Build();
+
+        var instance = container.Resolve<HasOverloadedConstructors>();
+
+        Assert.Equal(99, instance.Count);
+    }
+
+    [Fact]
+    public void DefaultComesFromTheShorterConstructorWhenItIsTheOneSelected()
+    {
+        var container = BuildContainer<HasOverloadedConstructors>();
+
+        var instance = container.Resolve<HasOverloadedConstructors>();
+
+        Assert.Equal(1, instance.Count);
+    }
+
+    [Fact]
+    public void ProtectedConstructorDefaultIsUsed()
+    {
+        // A protected constructor is mirrored by a public one on the proxy, so the
+        // container can select it where it couldn't on the unproxied type.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasProtectedConstructor>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(DoNothingInterceptor))
+            .WithParameter(TypedParameter.From("named"));
+        builder.RegisterType<DoNothingInterceptor>();
+        var container = builder.Build();
+
+        var instance = container.Resolve<HasProtectedConstructor>();
+
+        Assert.Equal(7, instance.Count);
+    }
+
+    [Fact]
+    public void OptionalDateTimeParameterUsesDefault()
+    {
+        var container = BuildContainer<HasOptionalDateTime>();
+
+        var instance = container.Resolve<HasOptionalDateTime>();
+
+        Assert.Equal(default, instance.When);
+    }
+
     private static IContainer BuildContainer<TService>()
         where TService : class
     {
@@ -142,6 +196,62 @@ public class ClassInterceptorsWithOptionalParametersFixture
         public virtual int GetCountByMethod()
         {
             return Count;
+        }
+    }
+
+    public class HasOptionalDateTime
+    {
+        public HasOptionalDateTime(DateTime when = default)
+        {
+            When = when;
+        }
+
+        public DateTime When
+        {
+            get;
+        }
+    }
+
+    public class HasOverloadedConstructors
+    {
+        public HasOverloadedConstructors(int count = 1)
+        {
+            Count = count;
+        }
+
+        public HasOverloadedConstructors(IDependency dependency, int count = 99)
+        {
+            Dependency = dependency;
+            Count = count;
+        }
+
+        public int Count
+        {
+            get;
+        }
+
+        public IDependency? Dependency
+        {
+            get;
+        }
+    }
+
+    public class HasProtectedConstructor
+    {
+        protected HasProtectedConstructor(string name, int count = 7)
+        {
+            Name = name;
+            Count = count;
+        }
+
+        public string Name
+        {
+            get;
+        }
+
+        public int Count
+        {
+            get;
         }
     }
 

--- a/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
+++ b/test/Autofac.Extras.DynamicProxy.Test/ClassInterceptorsWithOptionalParametersFixture.cs
@@ -105,6 +105,22 @@ public class ClassInterceptorsWithOptionalParametersFixture
     }
 
     [Fact]
+    public void DefaultComesFromTheRightConstructorWhenOverloadsTakeTheSameCount()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasSameArityConstructors>()
+            .EnableClassInterceptors()
+            .InterceptedBy(typeof(DoNothingInterceptor));
+        builder.RegisterType<DoNothingInterceptor>();
+        builder.RegisterType<Dependency>().As<IDependency>();
+        var container = builder.Build();
+
+        var instance = container.Resolve<HasSameArityConstructors>();
+
+        Assert.Equal(3, instance.Count);
+    }
+
+    [Fact]
     public void ProtectedConstructorDefaultIsUsed()
     {
         // A protected constructor is mirrored by a public one on the proxy, so
@@ -210,6 +226,36 @@ public class ClassInterceptorsWithOptionalParametersFixture
         }
 
         public IDependency? Dependency
+        {
+            get;
+        }
+    }
+
+    public class HasSameArityConstructors
+    {
+        public HasSameArityConstructors(IDependency dependency, int count = 3)
+        {
+            Dependency = dependency;
+            Count = count;
+        }
+
+        public HasSameArityConstructors(string name, int count = 4)
+        {
+            Name = name;
+            Count = count;
+        }
+
+        public int Count
+        {
+            get;
+        }
+
+        public IDependency? Dependency
+        {
+            get;
+        }
+
+        public string? Name
         {
             get;
         }


### PR DESCRIPTION
## Problem

Class interception rewrites `ActivatorData.ImplementationType` to a Castle-generated proxy subclass. The generated constructors mirror the parameters of the proxied type, but they do not carry those parameters' default values, so Autofac's `DefaultValueParameter` can't see them and optional constructor arguments fail to bind:

```text
None of the constructors found on type 'Castle.Proxies.MyServiceProxy' can be invoked
with the available services and parameters:
Cannot resolve parameter 'IDependency optional' of constructor
'Void .ctor(Castle.DynamicProxy.IInterceptor[], StatelessServiceContext, IDependency)'.
```

The same registration without `EnableClassInterceptors()` resolves fine, which is what makes this surprising: adding interception silently changes constructor binding.

This was reported downstream as autofac/Autofac.ServiceFabric#41. That integration class-intercepts *every* service registration in order to dispose the per-replica lifetime scope, so any Service Fabric service with an optional constructor argument is unresolvable. Nothing about it is Service Fabric specific though — it reproduces with a plain `RegisterType<T>().EnableClassInterceptors()`.

## Fix

Keep a reference to the type being proxied and supply its constructor default values on the proxy's behalf via a new internal `ProxiedDefaultValueParameter`.

It deliberately behaves as a last resort, deferring to everything that would otherwise win so that binding matches an unproxied registration:

1. Parameters passed to the resolve operation
2. Parameters configured on the registration (`WithParameter`)
3. Services available from the container (autowiring)
4. ...only then the proxied type's default value

The precedence checks matter because parameters added through `OnPreparing` are evaluated ahead of the activator's own `AutowiringParameter`/`DefaultValueParameter`. Without them this would shadow real registrations and configured parameters, silently substituting defaults for values the user supplied.

Required parameters that genuinely can't be satisfied still throw as before, so real misconfigurations aren't masked.

## Notes

- Added a `NotNullWhenAttribute` polyfill for `netstandard2.0`, following the existing pattern in `Autofac.Extensions.DependencyInjection`, since Autofac's own copy is `internal`.
- No public API change.

## Testing

New fixture `ClassInterceptorsWithOptionalParametersFixture` covers optional reference and value type arguments, each of the three precedence rules above, that interception still applies when an argument is defaulted, and that a missing required argument still throws.

Full build green on all four target frameworks: 53 tests pass (46 existing, 7 new), zero warnings.

Also verified end to end against the reporting scenario by temporarily project-referencing this branch from Autofac.ServiceFabric: a `StatelessService` with `(StatelessServiceContext context, IDependency? optional = null, int count = 42)` fails to resolve on `develop` and resolves correctly with this change.